### PR TITLE
Bug Fix: Invalid Keys Legacy Objects

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -62,7 +62,7 @@ func parseAttributes(buf string) ([]Attribute, error) {
 }
 
 func isValidKeyChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-'
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '*'
 }
 
 func isLineContinuationChar(c byte) bool {


### PR DESCRIPTION
This is a fix for the issue described in #8 

By including `*` as a potential value in `isValidKeyChar`, we allow the problematic `*xx` attributes to be parsed like any other attributes.

Another option would be to find a way to ignore this field, but this would enable any user that _may_ make use of these attributes to do so.