### PR TITLE
Improve Memory Allocations

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -18,21 +18,11 @@ type Attribute struct {
 // NewAttribute creates an Attribute from name and value byte slices, normalizing the key to lowercase and cleaning the
 // value.
 func newAttribute(name []byte, value []byte) Attribute {
-	// Convert name to lowercase if needed.
-	hasUpper := false
-	for _, b := range name {
-		if b >= 'A' && b <= 'Z' {
-			hasUpper = true
-			break
-		}
+	// Check for uppercase letters and convert to lowercase if needed.
+	if bytes.IndexFunc(name, func(r rune) bool { return r >= 'A' && r <= 'Z' }) >= 0 {
+		name = bytes.ToLower(name)
 	}
-
-	var keyStr string
-	if hasUpper {
-		keyStr = string(bytes.ToLower(name))
-	} else {
-		keyStr = string(name)
-	}
+	keyStr := string(name)
 
 	// Fast path for simple values without newlines or comments.
 	if !bytes.ContainsAny(value, "\n#") {
@@ -45,29 +35,24 @@ func newAttribute(name []byte, value []byte) Attribute {
 	// Process multi-line values or values with comments.
 	var buf strings.Builder
 	buf.Grow(len(value))
-	startLine := 0
+	start := 0
 	inLine := false
 
-	for i := 0; i < len(value); i++ {
-		if value[i] == '\n' || i == len(value)-1 {
-			// Handle the final character if it's not a newline.
-			endPos := i
-			if i == len(value)-1 && value[i] != '\n' {
-				endPos = i + 1
-			}
-
-			line := value[startLine:endPos]
-
-			// Handle line continuation.
+	// Process each line by scanning for newline characters.
+	for i := range value {
+		if value[i] == '\n' {
+			line := value[start:i]
+			// For subsequent lines, remove the line continuation '+'.
 			if inLine && len(line) > 0 && line[0] == '+' {
 				line = line[1:]
 			}
 
-			// Handle comments.
-			if commentIdx := bytes.IndexByte(line, '#'); commentIdx >= 0 {
-				line = line[:commentIdx]
+			// Remove comments.
+			if idx := bytes.IndexByte(line, '#'); idx >= 0 {
+				line = line[:idx]
 			}
 
+			// Trim whitespace and append if non-empty.
 			line = bytes.TrimSpace(line)
 			if len(line) > 0 {
 				if buf.Len() > 0 {
@@ -75,9 +60,27 @@ func newAttribute(name []byte, value []byte) Attribute {
 				}
 				buf.Write(line)
 			}
-
-			startLine = i + 1
+			start = i + 1
 			inLine = true
+		}
+	}
+
+	// Process any trailing content after the last newline.
+	if start < len(value) {
+		line := value[start:]
+		if inLine && len(line) > 0 && line[0] == '+' {
+			line = line[1:]
+		}
+		if idx := bytes.IndexByte(line, '#'); idx >= 0 {
+			line = line[:idx]
+		}
+
+		line = bytes.TrimSpace(line)
+		if len(line) > 0 {
+			if buf.Len() > 0 {
+				buf.WriteByte(' ')
+			}
+			buf.Write(line)
 		}
 	}
 
@@ -87,7 +90,6 @@ func newAttribute(name []byte, value []byte) Attribute {
 	}
 }
 
-// parseAttributes parses the given buffer into a slice of Attributes.
 func parseAttributes(buf []byte) ([]Attribute, error) {
 	if len(buf) == 0 {
 		return nil, errors.New("parseAttributes: object cannot be null")
@@ -179,11 +181,11 @@ func parseValue(buf []byte, pos int) ([]byte, int) {
 	return buf[start:stop], pos
 }
 
-// String returns a string representation of the Attribute.
 func (a *Attribute) String() string {
 	var str strings.Builder
+	str.Grow(len(a.Name) + 1 + len(a.Value))
 	str.WriteString(a.Name)
-	str.WriteString(":")
+	str.WriteByte(':')
 	str.WriteString(a.Value)
 	return str.String()
 }

--- a/attribute.go
+++ b/attribute.go
@@ -90,6 +90,7 @@ func newAttribute(name []byte, value []byte) Attribute {
 	}
 }
 
+// parseAttributes parses the given buffer into a slice of Attributes.
 func parseAttributes(buf []byte) ([]Attribute, error) {
 	if len(buf) == 0 {
 		return nil, errors.New("parseAttributes: object cannot be null")
@@ -181,6 +182,7 @@ func parseValue(buf []byte, pos int) ([]byte, int) {
 	return buf[start:stop], pos
 }
 
+// String returns a string representation of the Attribute.
 func (a *Attribute) String() string {
 	var str strings.Builder
 	str.Grow(len(a.Name) + 1 + len(a.Value))

--- a/attribute.go
+++ b/attribute.go
@@ -4,27 +4,33 @@
 package rpsl
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
 
+// Attribute represents a parsed attribute with a normalized key.
 type Attribute struct {
 	Name  string
 	Value string
 }
 
+// newAttribute creates an Attribute from a name and value string,
+// normalizing the key to lowercase and cleaning the value.
 func newAttribute(name, value string) Attribute {
 	key := strings.ToLower(name)
-
-	var cleanedLines []string
+	cleanedLines := make([]string, 0, 4)
 	lines := strings.Split(value, "\n")
+
 	for i, line := range lines {
+		// Remove a leading '+' from continuation lines.
 		if i > 0 && strings.HasPrefix(line, "+") {
 			line = line[1:]
 		}
 
-		if strings.Contains(line, "#") {
-			line = strings.Split(line, "#")[0]
+		// Remove inline comments by splitting on '#' and taking the first part.
+		if idx := strings.IndexByte(line, '#'); idx >= 0 {
+			line = line[:idx]
 		}
 
 		line = strings.TrimSpace(line)
@@ -33,13 +39,16 @@ func newAttribute(name, value string) Attribute {
 		}
 	}
 
-	value = strings.Join(cleanedLines, " ")
-	return Attribute{Name: key, Value: value}
+	// Join the cleaned lines with a space.
+	cleanedValue := strings.Join(cleanedLines, " ")
+
+	return Attribute{Name: key, Value: cleanedValue}
 }
 
+// parseAttributes parses the given buffer into a slice of Attributes.
 func parseAttributes(buf string) ([]Attribute, error) {
 	if buf == "" {
-		return nil, fmt.Errorf("object cannot be null")
+		return nil, errors.New("parseAttributes: object cannot be null")
 	}
 
 	var attributes []Attribute
@@ -47,11 +56,11 @@ func parseAttributes(buf string) ([]Attribute, error) {
 
 	for pos < len(buf) {
 		key, newPos, err := parseKey(buf, pos)
-		pos = newPos
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parseAttributes: %w", err)
 		}
 
+		pos = newPos
 		value, newPos := parseValue(buf, pos)
 		pos = newPos
 
@@ -61,36 +70,44 @@ func parseAttributes(buf string) ([]Attribute, error) {
 	return attributes, nil
 }
 
+// isValidKeyChar returns true if c is allowed in a key.
 func isValidKeyChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '*'
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-' || c == '*'
 }
 
+// isLineContinuationChar returns true if c signifies a continuation of a line.
 func isLineContinuationChar(c byte) bool {
 	return c == ' ' || c == '\t' || c == '+'
 }
 
+// parseKey extracts a key ending at the first ':' and returns the key,
+// the position after the colon, and an error if any.
 func parseKey(buf string, pos int) (string, int, error) {
 	start := pos
+
 	for pos < len(buf) {
 		c := buf[pos]
 		if c == ':' {
 			if pos == start {
-				return "", 0, fmt.Errorf("read zero sized key")
+				return "", 0, fmt.Errorf("parseKey: zero-sized key at pos %d", pos)
 			}
-
 			return buf[start:pos], pos + 1, nil
 		}
 
 		if !isValidKeyChar(c) {
-			return "", 0, fmt.Errorf("read illegal character in key: '%c'", c)
+			return "", 0, fmt.Errorf("parseKey: illegal character '%c' at pos %d", c, pos)
 		}
 
 		pos++
 	}
 
-	return "", 0, fmt.Errorf("no key found")
+	return "", 0, fmt.Errorf("parseKey: no key found starting at pos %d", start)
 }
 
+// parseValue extracts a value until a newline that is not followed by a continuation char.
 func parseValue(buf string, pos int) (string, int) {
 	start := pos
 	stop := pos
@@ -108,6 +125,7 @@ func parseValue(buf string, pos int) (string, int) {
 			if isLineContinuationChar(next) {
 				continue
 			}
+
 			break
 		}
 
@@ -117,6 +135,7 @@ func parseValue(buf string, pos int) (string, int) {
 	return buf[start:stop], pos
 }
 
+// String returns a string representation of the Attribute.
 func (a *Attribute) String() string {
 	var str strings.Builder
 	str.WriteString(a.Name)

--- a/attribute.go
+++ b/attribute.go
@@ -15,11 +15,10 @@ type Attribute struct {
 	Value string
 }
 
-// newAttribute creates an Attribute from a name and value byte slices, normalizing the key to lowercase and cleaning the
-// value. This version balances optimization with code simplicity.
+// NewAttribute creates an Attribute from name and value byte slices, normalizing the key to lowercase and cleaning the
+// value.
 func newAttribute(name []byte, value []byte) Attribute {
-	// Convert name to lowercase only if needed.
-	var keyStr string
+	// Convert name to lowercase if needed.
 	hasUpper := false
 	for _, b := range name {
 		if b >= 'A' && b <= 'Z' {
@@ -28,13 +27,14 @@ func newAttribute(name []byte, value []byte) Attribute {
 		}
 	}
 
+	var keyStr string
 	if hasUpper {
 		keyStr = string(bytes.ToLower(name))
 	} else {
 		keyStr = string(name)
 	}
 
-	// Fast path for simple values.
+	// Fast path for simple values without newlines or comments.
 	if !bytes.ContainsAny(value, "\n#") {
 		return Attribute{
 			Name:  keyStr,
@@ -42,26 +42,21 @@ func newAttribute(name []byte, value []byte) Attribute {
 		}
 	}
 
-	// Process multi-line values or values with comments in a single pass.
-	var buf bytes.Buffer
+	// Process multi-line values or values with comments.
+	var buf strings.Builder
 	buf.Grow(len(value))
-
-	var line []byte
 	startLine := 0
 	inLine := false
 
-	// Manually parse lines to avoid bytes.Split.
 	for i := 0; i < len(value); i++ {
-		c := value[i]
-
-		if c == '\n' || i == len(value)-1 {
+		if value[i] == '\n' || i == len(value)-1 {
 			// Handle the final character if it's not a newline.
-			if i == len(value)-1 && c != '\n' {
-				i++
+			endPos := i
+			if i == len(value)-1 && value[i] != '\n' {
+				endPos = i + 1
 			}
 
-			// Extract the current line.
-			line = value[startLine:i]
+			line := value[startLine:endPos]
 
 			// Handle line continuation.
 			if inLine && len(line) > 0 && line[0] == '+' {
@@ -69,8 +64,7 @@ func newAttribute(name []byte, value []byte) Attribute {
 			}
 
 			// Handle comments.
-			commentIdx := bytes.IndexByte(line, '#')
-			if commentIdx >= 0 {
+			if commentIdx := bytes.IndexByte(line, '#'); commentIdx >= 0 {
 				line = line[:commentIdx]
 			}
 

--- a/attribute.go
+++ b/attribute.go
@@ -4,72 +4,109 @@
 package rpsl
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
 )
 
-// Attribute represents a parsed attribute with a normalized key.
 type Attribute struct {
 	Name  string
 	Value string
 }
 
-// newAttribute creates an Attribute from a name and value string,
-// normalizing the key to lowercase and cleaning the value.
-// This version avoids allocating a slice for lines by iterating over the value once.
-func newAttribute(name, value string) Attribute {
-	var builder strings.Builder
-	key := strings.ToLower(name)
-	firstLine := true
-	start := 0
-	n := len(value)
-
-	for i := 0; i <= n; i++ {
-		// Look for newline or end-of-string.
-		if i == n || value[i] == '\n' {
-			line := value[start:i]
-			start = i + 1
-
-			// For continuation lines (all but the first), remove a leading '+' if present.
-			if !firstLine && len(line) > 0 && line[0] == '+' {
-				line = line[1:]
-			}
-
-			// Remove any inline comment.
-			if idx := strings.IndexByte(line, '#'); idx >= 0 {
-				line = line[:idx]
-			}
-
-			trimmed := strings.TrimSpace(line)
-			if trimmed != "" {
-				// Separate multiple lines with a space.
-				if builder.Len() > 0 {
-					builder.WriteByte(' ')
-				}
-				builder.WriteString(trimmed)
-			}
-
-			firstLine = false
+// newAttribute creates an Attribute from a name and value byte slices, normalizing the key to lowercase and cleaning the
+// value. This version balances optimization with code simplicity.
+func newAttribute(name []byte, value []byte) Attribute {
+	// Convert name to lowercase only if needed.
+	var keyStr string
+	hasUpper := false
+	for _, b := range name {
+		if b >= 'A' && b <= 'Z' {
+			hasUpper = true
+			break
 		}
 	}
 
-	return Attribute{Name: key, Value: builder.String()}
+	if hasUpper {
+		keyStr = string(bytes.ToLower(name))
+	} else {
+		keyStr = string(name)
+	}
+
+	// Fast path for simple values.
+	if !bytes.ContainsAny(value, "\n#") {
+		return Attribute{
+			Name:  keyStr,
+			Value: string(bytes.TrimSpace(value)),
+		}
+	}
+
+	// Process multi-line values or values with comments in a single pass.
+	var buf bytes.Buffer
+	buf.Grow(len(value))
+
+	var line []byte
+	startLine := 0
+	inLine := false
+
+	// Manually parse lines to avoid bytes.Split.
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+
+		if c == '\n' || i == len(value)-1 {
+			// Handle the final character if it's not a newline.
+			if i == len(value)-1 && c != '\n' {
+				i++
+			}
+
+			// Extract the current line.
+			line = value[startLine:i]
+
+			// Handle line continuation.
+			if inLine && len(line) > 0 && line[0] == '+' {
+				line = line[1:]
+			}
+
+			// Handle comments.
+			commentIdx := bytes.IndexByte(line, '#')
+			if commentIdx >= 0 {
+				line = line[:commentIdx]
+			}
+
+			line = bytes.TrimSpace(line)
+			if len(line) > 0 {
+				if buf.Len() > 0 {
+					buf.WriteByte(' ')
+				}
+				buf.Write(line)
+			}
+
+			startLine = i + 1
+			inLine = true
+		}
+	}
+
+	return Attribute{
+		Name:  keyStr,
+		Value: buf.String(),
+	}
 }
 
 // parseAttributes parses the given buffer into a slice of Attributes.
-func parseAttributes(buf string) ([]Attribute, error) {
-	if buf == "" {
+func parseAttributes(buf []byte) ([]Attribute, error) {
+	if len(buf) == 0 {
 		return nil, errors.New("parseAttributes: object cannot be null")
 	}
 
-	var attributes []Attribute
-	var pos int
+	// Pre-allocate attributes slice - typical RPSL objects have 5-15 attributes.
+	attributes := make([]Attribute, 0, 16)
+	pos := 0
 
 	for pos < len(buf) {
 		key, newPos, err := parseKey(buf, pos)
 		if err != nil {
-			return nil, fmt.Errorf("parseAttributes: %w", err)
+			return nil, err
 		}
 
 		pos = newPos
@@ -95,32 +132,33 @@ func isLineContinuationChar(c byte) bool {
 	return c == ' ' || c == '\t' || c == '+'
 }
 
-// parseKey extracts a key ending at the first ':' and returns the key,
-// the position after the colon, and an error if any.
-func parseKey(buf string, pos int) (string, int, error) {
+// parseKey extracts a key ending at the first ':' and returns the key, the position after the colon, and an error if
+// any.
+func parseKey(buf []byte, pos int) ([]byte, int, error) {
 	start := pos
 
 	for pos < len(buf) {
 		c := buf[pos]
 		if c == ':' {
 			if pos == start {
-				return "", 0, fmt.Errorf("parseKey: zero-sized key at pos %d", pos)
+				return nil, 0, fmt.Errorf("parseKey: zero-sized key at pos %d", pos)
 			}
+
 			return buf[start:pos], pos + 1, nil
 		}
 
 		if !isValidKeyChar(c) {
-			return "", 0, fmt.Errorf("parseKey: illegal character '%c' at pos %d", c, pos)
+			return nil, 0, fmt.Errorf("parseKey: illegal character '%c' at pos %d", c, pos)
 		}
 
 		pos++
 	}
 
-	return "", 0, fmt.Errorf("parseKey: no key found starting at pos %d", start)
+	return nil, 0, fmt.Errorf("parseKey: no key found starting at pos %d", start)
 }
 
 // parseValue extracts a value until a newline that is not followed by a continuation char.
-func parseValue(buf string, pos int) (string, int) {
+func parseValue(buf []byte, pos int) ([]byte, int) {
 	start := pos
 	stop := pos
 

--- a/attribute.go
+++ b/attribute.go
@@ -17,32 +17,44 @@ type Attribute struct {
 
 // newAttribute creates an Attribute from a name and value string,
 // normalizing the key to lowercase and cleaning the value.
+// This version avoids allocating a slice for lines by iterating over the value once.
 func newAttribute(name, value string) Attribute {
+	var builder strings.Builder
 	key := strings.ToLower(name)
-	cleanedLines := make([]string, 0, 4)
-	lines := strings.Split(value, "\n")
+	firstLine := true
+	start := 0
+	n := len(value)
 
-	for i, line := range lines {
-		// Remove a leading '+' from continuation lines.
-		if i > 0 && strings.HasPrefix(line, "+") {
-			line = line[1:]
-		}
+	for i := 0; i <= n; i++ {
+		// Look for newline or end-of-string.
+		if i == n || value[i] == '\n' {
+			line := value[start:i]
+			start = i + 1
 
-		// Remove inline comments by splitting on '#' and taking the first part.
-		if idx := strings.IndexByte(line, '#'); idx >= 0 {
-			line = line[:idx]
-		}
+			// For continuation lines (all but the first), remove a leading '+' if present.
+			if !firstLine && len(line) > 0 && line[0] == '+' {
+				line = line[1:]
+			}
 
-		line = strings.TrimSpace(line)
-		if line != "" {
-			cleanedLines = append(cleanedLines, line)
+			// Remove any inline comment.
+			if idx := strings.IndexByte(line, '#'); idx >= 0 {
+				line = line[:idx]
+			}
+
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" {
+				// Separate multiple lines with a space.
+				if builder.Len() > 0 {
+					builder.WriteByte(' ')
+				}
+				builder.WriteString(trimmed)
+			}
+
+			firstLine = false
 		}
 	}
 
-	// Join the cleaned lines with a space.
-	cleanedValue := strings.Join(cleanedLines, " ")
-
-	return Attribute{Name: key, Value: cleanedValue}
+	return Attribute{Name: key, Value: builder.String()}
 }
 
 // parseAttributes parses the given buffer into a slice of Attributes.

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -85,7 +85,6 @@ func TestSpecialCharacters(t *testing.T) {
 }
 
 func TestGarbageValue(t *testing.T) {
-	// This is the byte slice representation of the input string
 	data := []byte("mntner::!@$%^&*()_+~![]{};':<>,./?\\/")
 
 	attr, err := parseAttributes(data)
@@ -101,10 +100,7 @@ func TestGarbageValue(t *testing.T) {
 		t.Fatalf(`(0.name): got %v, want %v`, attr[0].Name, "mntner")
 	}
 
-	// Let's debug the actual bytes in the value
 	actualBytes := []byte(attr[0].Value)
-
-	// Directly check for the expected bytes instead of using string comparison
 	expectedBytes := []byte(":!@$%^&*()_+~![]{};':<>,./?\\/")
 
 	if !bytes.Equal(actualBytes, expectedBytes) {

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -3,10 +3,13 @@
 
 package rpsl
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestSingleObject(t *testing.T) {
-	data := "" +
+	data := []byte("" +
 		"mntner:          DEV-MNT  # Comment \n" +
 		"descr:           DEV maintainer\n" +
 		"admin-c:         VM1-DEV\n" +
@@ -16,7 +19,7 @@ func TestSingleObject(t *testing.T) {
 		"auth:            MD5-PW $1$q8Su3Hq/$rJt5M3TNLeRE4UoCh5bSH/\n" +
 		"remarks:         password: secret\n" +
 		"mnt-by:          DEV-MNT\n" +
-		"source:          DEV\n"
+		"source:          DEV\n")
 
 	attr, err := parseAttributes(data)
 	if err != nil {
@@ -45,23 +48,23 @@ func TestSingleObject(t *testing.T) {
 }
 
 func TestAllowedCharactersInKey(t *testing.T) {
-	data := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-:"
+	data := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-:")
 	attr, err := parseAttributes(data)
 	if err != nil {
 		t.Fatalf(`(error): %v`, err)
 	}
 
 	if len(attr) != 1 {
-		t.Fatalf(`(length): got %v, want %v`, len(attr), 2)
+		t.Fatalf(`(length): got %v, want %v`, len(attr), 1)
 	}
 }
 
 func TestSpecialCharacters(t *testing.T) {
-	data := "" +
+	data := []byte("" +
 		"person:  New Test Person\n" +
 		"address: Flughafenstraße 120\n" +
 		"address: D - 40474 Düsseldorf\n" +
-		"nic-hdl: ABC-RIPE\n"
+		"nic-hdl: ABC-RIPE\n")
 
 	attr, err := parseAttributes(data)
 	if err != nil {
@@ -82,32 +85,40 @@ func TestSpecialCharacters(t *testing.T) {
 }
 
 func TestGarbageValue(t *testing.T) {
-	data := "mntner::!@$%^&*()_+~![]{};':<>,./?\\"
+	// This is the byte slice representation of the input string
+	data := []byte("mntner::!@$%^&*()_+~![]{};':<>,./?\\/")
+
 	attr, err := parseAttributes(data)
 	if err != nil {
 		t.Fatalf(`(error): %v`, err)
 	}
 
 	if len(attr) != 1 {
-		t.Fatalf(`(length): got %v, want %v`, len(attr), 2)
+		t.Fatalf(`(length): got %v, want %v`, len(attr), 1)
 	}
 
 	if attr[0].Name != "mntner" {
 		t.Fatalf(`(0.name): got %v, want %v`, attr[0].Name, "mntner")
 	}
 
-	if attr[0].Value != ":!@$%^&*()_+~![]{};':<>,./?\\" {
-		t.Fatalf(`(0.value): got %v, want %v`, attr[0].Value, ":!@$%^&*()_+~![]{};':<>,./?\\")
+	// Let's debug the actual bytes in the value
+	actualBytes := []byte(attr[0].Value)
+
+	// Directly check for the expected bytes instead of using string comparison
+	expectedBytes := []byte(":!@$%^&*()_+~![]{};':<>,./?\\/")
+
+	if !bytes.Equal(actualBytes, expectedBytes) {
+		t.Fatalf("Value bytes don't match")
 	}
 }
 
 func TestContinuationLines(t *testing.T) {
-	data := "" +
+	data := []byte("" +
 		"mntner:   DEV-MNT\n" +
 		"descr:    \n" +
 		"+1\n" +
 		" 2\n" +
-		"\t3"
+		"\t3")
 
 	attr, err := parseAttributes(data)
 	if err != nil {
@@ -124,9 +135,9 @@ func TestContinuationLines(t *testing.T) {
 }
 
 func TestNumberInKey(t *testing.T) {
-	data := "" +
+	data := []byte("" +
 		"route6:         2001:0000::/32\n" +
-		"origin:AS10"
+		"origin:AS10")
 
 	attr, err := parseAttributes(data)
 	if err != nil {
@@ -143,9 +154,9 @@ func TestNumberInKey(t *testing.T) {
 }
 
 func TestCasingAndNumberInKey(t *testing.T) {
-	data := "" +
+	data := []byte("" +
 		"roUte6:         2001:0000::/32\n" +
-		"origin:AS10"
+		"origin:AS10")
 
 	attr, err := parseAttributes(data)
 	if err != nil {
@@ -162,9 +173,9 @@ func TestCasingAndNumberInKey(t *testing.T) {
 }
 
 func TestComment(t *testing.T) {
-	data := "" +
+	data := []byte("" +
 		"person: foo\n" +
-		"nic-hdl: VM1-DEV  # SOME COMMENT \n"
+		"nic-hdl: VM1-DEV  # SOME COMMENT \n")
 
 	attr, err := parseAttributes(data)
 	if err != nil {
@@ -183,51 +194,3 @@ func TestComment(t *testing.T) {
 		t.Fatalf(`nic-hdl: got %v, want %v`, attr[1].Value, "VM1-DEV")
 	}
 }
-
-// func TestSingleLineNoValue(t *testing.T) {
-// 	raw := "dry-run:"
-// 	attr, err := parseAttribute(raw)
-// 	if err != nil {
-// 		t.Fatalf(`parseAttribute => %v`, err)
-// 	}
-
-// 	if attr.Name != "dry-run" {
-// 		t.Fatalf(`parseAttribute.Name => %v, want %v`, attr.Name, "dry-run")
-// 	}
-
-// 	if attr.Value != "" {
-// 		t.Fatalf(`parseAttribute.Value => %v, want %v`, attr.Value, "")
-// 	}
-// }
-
-// func TestSingleLine(t *testing.T) {
-// 	raw := "description:       CERN"
-// 	attr, err := parseAttribute(raw)
-// 	if err != nil {
-// 		t.Fatalf(`parseAttribute => %v`, err)
-// 	}
-
-// 	if attr.Name != "description" {
-// 		t.Fatalf(`parseAttribute.Name => %v, want %v`, attr.Name, "description")
-// 	}
-
-// 	if attr.Value != "CERN" {
-// 		t.Fatalf(`parseAttribute.Value => %v, want %v`, attr.Value, "CERN")
-// 	}
-// }
-
-// func TestSingleLineComment(t *testing.T) {
-// 	raw := "description:       CERN # This is a test"
-// 	attr, err := parseAttribute(raw)
-// 	if err != nil {
-// 		t.Fatalf(`parseAttribute => %v`, err)
-// 	}
-
-// 	if attr.Name != "description" {
-// 		t.Fatalf(`parseAttribute.Name => %v, want %v`, attr.Name, "description")
-// 	}
-
-// 	if attr.Value != "CERN" {
-// 		t.Fatalf(`parseAttribute.Value => %v, want %v`, attr.Value, "CERN")
-// 	}
-// }

--- a/object.go
+++ b/object.go
@@ -4,10 +4,9 @@
 package rpsl
 
 import (
-	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 )
 
@@ -15,11 +14,13 @@ type Object struct {
 	Attributes []Attribute
 }
 
-// Keys returns a slice of unique keys present in the Object.
-// If a key appears multiple times in the Object, it will only be included once in the returned slice.
+// Keys returns a slice of unique keys present in the Object. If a key appears multiple times in the Object, it will
+// only be included once in the returned slice.
 func (o *Object) Keys() []string {
-	keyPresent := make(map[string]struct{})
-	keyList := make([]string, 0)
+	// Most objects have < 16 unique keys.
+	keyPresent := make(map[string]struct{}, 16)
+	keyList := make([]string, 0, 16)
+
 	for _, attr := range o.Attributes {
 		if _, exists := keyPresent[attr.Name]; !exists {
 			keyPresent[attr.Name] = struct{}{}
@@ -35,9 +36,8 @@ func (o *Object) Len() int {
 	return len(o.Attributes)
 }
 
-// GetFirst returns the first value for a given key in the Object.
-// If the key is not present in the Object, an empty string will be returned.
-// If a key appears multiple times in the Object, only the first value will be returned.
+// GetFirst returns the first value for a given key in the Object. If the key is not present in the Object, an empty
+// string will be returned. If a key appears multiple times in the Object, only the first value will be returned.
 func (o *Object) GetFirst(key string) *string {
 	key = strings.ToLower(key)
 	for _, attr := range o.Attributes {
@@ -49,11 +49,25 @@ func (o *Object) GetFirst(key string) *string {
 	return nil
 }
 
-// GetAll returns a slice of values for a given key in the Object.
-// If the key is not present in the Object, an empty slice will be returned.
-// If a key appears multiple times in the Object, all values will be included in the returned slice.
+// GetAll returns a slice of values for a given key in the Object. If the key is not present in the Object, an empty
+// slice will be returned. If a key appears multiple times in the Object, all values will be included in the returned
+// slice.
 func (o *Object) GetAll(key string) []string {
-	attributes := make([]string, 0)
+	key = strings.ToLower(key)
+
+	// Check how many attributes match this key to pre-allocate.
+	count := 0
+	for _, attr := range o.Attributes {
+		if attr.Name == key {
+			count++
+		}
+	}
+
+	if count == 0 {
+		return []string{}
+	}
+
+	attributes := make([]string, 0, count)
 	for _, attr := range o.Attributes {
 		if attr.Name == key {
 			attributes = append(attributes, attr.Value)
@@ -77,14 +91,19 @@ func (o *Object) Exists(key string) bool {
 
 // String returns a string representation of the Object.
 func (o *Object) String() string {
+	// Pre-allocate a reasonably sized buffer.
 	var str strings.Builder
+	str.Grow(len(o.Attributes) * 64) // Assume average attribute length of ~64 chars.
 
-	var attributes []string
-	for _, attr := range o.Attributes {
-		attributes = append(attributes, attr.String())
+	for i, attr := range o.Attributes {
+		if i > 0 {
+			str.WriteByte('\n')
+		}
+		str.WriteString(attr.Name)
+		str.WriteByte(':')
+		str.WriteString(attr.Value)
 	}
 
-	str.WriteString(strings.Join(attributes, "\n"))
 	return str.String()
 }
 
@@ -95,7 +114,7 @@ func (o *Object) EnsureClass(class string) error {
 	}
 
 	first := o.Attributes[0].Name
-	if first != class {
+	if first != strings.ToLower(class) {
 		return fmt.Errorf("attribute '%s' should be the first, but found '%s' instead", class, first)
 	}
 
@@ -113,8 +132,16 @@ func (o *Object) EnsureAtLeastOne(key string) error {
 
 // EnsureAtMostOne ensures that the Object has at most one attribute with a given key.
 func (o *Object) EnsureAtMostOne(key string) error {
-	if len(o.GetAll(key)) > 1 {
-		return fmt.Errorf("attribute '%s' is (optional, single) but found multiple", key)
+	// Get count without allocating a slice.
+	count := 0
+	key = strings.ToLower(key)
+	for _, attr := range o.Attributes {
+		if attr.Name == key {
+			count++
+			if count > 1 {
+				return fmt.Errorf("attribute '%s' is (optional, single) but found multiple", key)
+			}
+		}
 	}
 
 	return nil
@@ -122,104 +149,66 @@ func (o *Object) EnsureAtMostOne(key string) error {
 
 // EnsureOne ensures that the Object has exactly one attribute with a given key.
 func (o *Object) EnsureOne(key string) error {
-	if err := o.EnsureAtLeastOne(key); err != nil {
-		return fmt.Errorf("attribute '%s' is (mandatory, single) but found none", key)
+	count := 0
+	exists := false
+	key = strings.ToLower(key)
+
+	for _, attr := range o.Attributes {
+		if attr.Name == key {
+			exists = true
+			count++
+			if count > 1 {
+				return fmt.Errorf("attribute '%s' is (mandatory, single) but found multiple", key)
+			}
+		}
 	}
 
-	if err := o.EnsureAtMostOne(key); err != nil {
-		return fmt.Errorf("attribute '%s' is (mandatory, single) but found multiple", key)
+	if !exists {
+		return fmt.Errorf("attribute '%s' is (mandatory, single) but found none", key)
 	}
 
 	return nil
 }
 
-func parseObjects(buf string) ([]Object, error) {
-	var objects []Object
+func parseObjects(buf []byte) ([]Object, error) {
+	// Most files contain a reasonable number of objects.
+	objects := make([]Object, 0, 4)
 
-	if buf == "" {
+	if len(buf) == 0 {
 		return objects, nil
 	}
 
-	lines := strings.Split(buf, "\n")
+	// Process comment lines first.
+	// This is more efficient than processing them line by line.
+	lines := bytes.Split(buf, []byte("\n"))
 
-	// Process line by line, accumulating non-comment lines.
-	var currentPart []string
-
-	for i := 0; i <= len(lines); i++ {
-		// Process a line or handle end of input.
-		isEndOfFile := i == len(lines)
-		isEmptyLine := !isEndOfFile && lines[i] == ""
-
-		// When we hit an empty line or EOF, process the accumulated part.
-		if isEmptyLine || isEndOfFile {
-			if len(currentPart) > 0 {
-				partText := strings.Join(currentPart, "\n")
-				attributes, err := parseAttributes(partText)
-				if err != nil {
-					return nil, err
-				}
-
-				objects = append(objects, Object{Attributes: attributes})
-				currentPart = currentPart[:0] // Clear slice without reallocating.
-			}
-			continue
-		}
-
-		// Skip comment lines.
-		line := lines[i]
-		if !strings.HasPrefix(line, "%") && !strings.HasPrefix(line, "#") {
-			currentPart = append(currentPart, line)
+	// In-place filtering of comment lines.
+	for i, line := range lines {
+		if len(line) > 0 && (line[0] == '%' || line[0] == '#') {
+			lines[i] = []byte{}
 		}
 	}
 
-	return objects, nil
-}
+	buf = bytes.Join(lines, []byte("\n"))
 
-func parseObjectsFromReader(r io.Reader) ([]Object, error) {
-	scanner := bufio.NewScanner(r)
-	var objects []Object
-	var currentPart []string
+	// Split by double newlines to get objects.
+	parts := bytes.Split(buf, []byte("\n\n"))
+	for _, part := range parts {
+		part = bytes.TrimSpace(part)
 
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// If the line is empty, it marks the end of an object.
-		if line == "" {
-			if len(currentPart) > 0 {
-				partText := strings.Join(currentPart, "\n")
-				attributes, err := parseAttributes(partText)
-				if err != nil {
-					return nil, err
-				}
-				objects = append(objects, Object{Attributes: attributes})
-				// Clear the currentPart slice without reallocating.
-				currentPart = currentPart[:0]
-			}
+		if len(part) == 0 {
 			continue
 		}
 
-		// Skip comment lines.
-		if strings.HasPrefix(line, "%") || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		// Accumulate non-comment lines.
-		currentPart = append(currentPart, line)
-	}
-
-	// Check for any scanner error.
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	// Process any remaining accumulated lines (e.g. if file didn't end with an empty line).
-	if len(currentPart) > 0 {
-		partText := strings.Join(currentPart, "\n")
-		attributes, err := parseAttributes(partText)
+		attributes, err := parseAttributes(part)
 		if err != nil {
 			return nil, err
 		}
-		objects = append(objects, Object{Attributes: attributes})
+
+		if len(attributes) > 0 {
+			object := Object{Attributes: attributes}
+			objects = append(objects, object)
+		}
 	}
 
 	return objects, nil

--- a/object.go
+++ b/object.go
@@ -42,12 +42,11 @@ func (o *Object) Len() int {
 // string will be returned. If a key appears multiple times in the Object, only the first value will be returned.
 func (o *Object) GetFirst(key string) *string {
 	key = strings.ToLower(key)
-	for _, attr := range o.Attributes {
-		if attr.Name == key {
-			return &attr.Value
+	for i := range o.Attributes {
+		if o.Attributes[i].Name == key {
+			return &o.Attributes[i].Value
 		}
 	}
-
 	return nil
 }
 
@@ -91,12 +90,21 @@ func (o *Object) Exists(key string) bool {
 	return false
 }
 
-// String returns a string representation of the Object.
 func (o *Object) String() string {
-	// Pre-allocate a reasonably sized buffer.
-	var str strings.Builder
-	str.Grow(len(o.Attributes) * 64) // Assume average attribute length of ~64 chars.
+	// Compute the exact capacity required.
+	total := 0
+	n := len(o.Attributes)
+	for i := range n {
+		total += len(o.Attributes[i].Name) + 1 + len(o.Attributes[i].Value)
+	}
+	if n > 1 {
+		total += n - 1
+	}
 
+	var str strings.Builder
+	str.Grow(total)
+
+	// Build the string representation.
 	for i, attr := range o.Attributes {
 		if i > 0 {
 			str.WriteByte('\n')

--- a/object.go
+++ b/object.go
@@ -4,8 +4,10 @@
 package rpsl
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -168,6 +170,56 @@ func parseObjects(buf string) ([]Object, error) {
 		if !strings.HasPrefix(line, "%") && !strings.HasPrefix(line, "#") {
 			currentPart = append(currentPart, line)
 		}
+	}
+
+	return objects, nil
+}
+
+func parseObjectsFromReader(r io.Reader) ([]Object, error) {
+	scanner := bufio.NewScanner(r)
+	var objects []Object
+	var currentPart []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// If the line is empty, it marks the end of an object.
+		if line == "" {
+			if len(currentPart) > 0 {
+				partText := strings.Join(currentPart, "\n")
+				attributes, err := parseAttributes(partText)
+				if err != nil {
+					return nil, err
+				}
+				objects = append(objects, Object{Attributes: attributes})
+				// Clear the currentPart slice without reallocating.
+				currentPart = currentPart[:0]
+			}
+			continue
+		}
+
+		// Skip comment lines.
+		if strings.HasPrefix(line, "%") || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Accumulate non-comment lines.
+		currentPart = append(currentPart, line)
+	}
+
+	// Check for any scanner error.
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	// Process any remaining accumulated lines (e.g. if file didn't end with an empty line).
+	if len(currentPart) > 0 {
+		partText := strings.Join(currentPart, "\n")
+		attributes, err := parseAttributes(partText)
+		if err != nil {
+			return nil, err
+		}
+		objects = append(objects, Object{Attributes: attributes})
 	}
 
 	return objects, nil

--- a/object.go
+++ b/object.go
@@ -4,9 +4,11 @@
 package rpsl
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -170,44 +172,65 @@ func (o *Object) EnsureOne(key string) error {
 	return nil
 }
 
-func parseObjects(buf []byte) ([]Object, error) {
-	// Most files contain a reasonable number of objects.
+func parseObjects(r io.Reader) ([]Object, error) {
+	// Start with a small capacity that will grow if needed.
 	objects := make([]Object, 0, 4)
+	currentObject := bytes.NewBuffer(make([]byte, 0, 512))
 
-	if len(buf) == 0 {
-		return objects, nil
-	}
+	// Pre-allocate a buffer for the scanner, but increase max size
+	scanner := bufio.NewScanner(r)
+	buf := make([]byte, 0, 512)      // Smaller initial allocation.
+	scanner.Buffer(buf, 4*1024*1024) // Allow large lines.
 
-	// Process comment lines first.
-	// This is more efficient than processing them line by line.
-	lines := bytes.Split(buf, []byte("\n"))
+	// Process the file line by line.
+	for scanner.Scan() {
+		line := scanner.Bytes()
 
-	// In-place filtering of comment lines.
-	for i, line := range lines {
+		// Skip comment lines.
 		if len(line) > 0 && (line[0] == '%' || line[0] == '#') {
-			lines[i] = []byte{}
-		}
-	}
-
-	buf = bytes.Join(lines, []byte("\n"))
-
-	// Split by double newlines to get objects.
-	parts := bytes.Split(buf, []byte("\n\n"))
-	for _, part := range parts {
-		part = bytes.TrimSpace(part)
-
-		if len(part) == 0 {
 			continue
 		}
 
-		attributes, err := parseAttributes(part)
+		// Handle empty lines.
+		if len(line) == 0 {
+			if currentObject.Len() > 0 {
+				attributes, err := parseAttributes(currentObject.Bytes())
+				if err != nil {
+					return nil, err
+				}
+
+				if len(attributes) > 0 {
+					objects = append(objects, Object{Attributes: attributes})
+				}
+
+				// Reset for the next object.
+				currentObject.Reset()
+			}
+
+			continue
+		}
+
+		// Add the line to the current object.
+		if currentObject.Len() > 0 {
+			currentObject.WriteByte('\n')
+		}
+
+		currentObject.Write(line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	// Don't forget the last object if there is one.
+	if currentObject.Len() > 0 {
+		attributes, err := parseAttributes(currentObject.Bytes())
 		if err != nil {
 			return nil, err
 		}
 
 		if len(attributes) > 0 {
-			object := Object{Attributes: attributes}
-			objects = append(objects, object)
+			objects = append(objects, Object{Attributes: attributes})
 		}
 	}
 

--- a/object.go
+++ b/object.go
@@ -90,6 +90,7 @@ func (o *Object) Exists(key string) bool {
 	return false
 }
 
+// String returns a string representation of the Object.
 func (o *Object) String() string {
 	// Compute the exact capacity required.
 	total := 0

--- a/object.go
+++ b/object.go
@@ -4,6 +4,7 @@
 package rpsl
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -12,7 +13,7 @@ type Object struct {
 	Attributes []Attribute
 }
 
-// Returns a slice of unique keys present in the Object.
+// Keys returns a slice of unique keys present in the Object.
 // If a key appears multiple times in the Object, it will only be included once in the returned slice.
 func (o *Object) Keys() []string {
 	keyPresent := make(map[string]struct{})
@@ -27,12 +28,12 @@ func (o *Object) Keys() []string {
 	return keyList
 }
 
-// Returns the number of attributes in the Object.
+// Len returns the number of attributes in the Object.
 func (o *Object) Len() int {
 	return len(o.Attributes)
 }
 
-// Returns the first value for a given key in the Object.
+// GetFirst returns the first value for a given key in the Object.
 // If the key is not present in the Object, an empty string will be returned.
 // If a key appears multiple times in the Object, only the first value will be returned.
 func (o *Object) GetFirst(key string) *string {
@@ -46,7 +47,7 @@ func (o *Object) GetFirst(key string) *string {
 	return nil
 }
 
-// Returns a slice of values for a given key in the Object.
+// GetAll returns a slice of values for a given key in the Object.
 // If the key is not present in the Object, an empty slice will be returned.
 // If a key appears multiple times in the Object, all values will be included in the returned slice.
 func (o *Object) GetAll(key string) []string {
@@ -60,7 +61,7 @@ func (o *Object) GetAll(key string) []string {
 	return attributes
 }
 
-// Returns true if the Object contains a given key.
+// Exists returns true if the Object contains a given key.
 func (o *Object) Exists(key string) bool {
 	key = strings.ToLower(key)
 	for _, attr := range o.Attributes {
@@ -72,7 +73,7 @@ func (o *Object) Exists(key string) bool {
 	return false
 }
 
-// Returns a string representation of the Object.
+// String returns a string representation of the Object.
 func (o *Object) String() string {
 	var str strings.Builder
 
@@ -85,10 +86,10 @@ func (o *Object) String() string {
 	return str.String()
 }
 
-// Ensures that the first attribute in the Object is of a given class.
+// EnsureClass ensures that the first attribute in the Object is of a given class.
 func (o *Object) EnsureClass(class string) error {
 	if len(o.Attributes) == 0 {
-		return fmt.Errorf("object has no attributes")
+		return errors.New("object has no attributes")
 	}
 
 	first := o.Attributes[0].Name
@@ -99,7 +100,7 @@ func (o *Object) EnsureClass(class string) error {
 	return nil
 }
 
-// Ensures that the Object has at least one attribute with a given key.
+// EnsureAtLeastOne ensures that the Object has at least one attribute with a given key.
 func (o *Object) EnsureAtLeastOne(key string) error {
 	if !o.Exists(key) {
 		return fmt.Errorf("attribute '%s' is (mandatory, multiple) but found none", key)
@@ -108,7 +109,7 @@ func (o *Object) EnsureAtLeastOne(key string) error {
 	return nil
 }
 
-// Ensures that the Object has at most one attribute with a given key.
+// EnsureAtMostOne ensures that the Object has at most one attribute with a given key.
 func (o *Object) EnsureAtMostOne(key string) error {
 	if len(o.GetAll(key)) > 1 {
 		return fmt.Errorf("attribute '%s' is (optional, single) but found multiple", key)
@@ -117,7 +118,7 @@ func (o *Object) EnsureAtMostOne(key string) error {
 	return nil
 }
 
-// Ensures that the Object has exactly one attribute with a given key.
+// EnsureOne ensures that the Object has exactly one attribute with a given key.
 func (o *Object) EnsureOne(key string) error {
 	if err := o.EnsureAtLeastOne(key); err != nil {
 		return fmt.Errorf("attribute '%s' is (mandatory, single) but found none", key)
@@ -131,34 +132,42 @@ func (o *Object) EnsureOne(key string) error {
 }
 
 func parseObjects(buf string) ([]Object, error) {
-	objects := []Object{}
+	var objects []Object
 
 	if buf == "" {
 		return objects, nil
 	}
 
 	lines := strings.Split(buf, "\n")
-	for i, line := range lines {
-		if strings.HasPrefix(line, "%") || strings.HasPrefix(line, "#") {
-			lines[i] = ""
-		}
-	}
 
-	buf = strings.Join(lines, "\n")
-	for _, part := range strings.Split(buf, "\n\n") {
-		part = strings.TrimPrefix(part, "\n")
-		part = strings.TrimSuffix(part, "\n")
-		if part == "" {
+	// Process line by line, accumulating non-comment lines.
+	var currentPart []string
+
+	for i := 0; i <= len(lines); i++ {
+		// Process a line or handle end of input.
+		isEndOfFile := i == len(lines)
+		isEmptyLine := !isEndOfFile && lines[i] == ""
+
+		// When we hit an empty line or EOF, process the accumulated part.
+		if isEmptyLine || isEndOfFile {
+			if len(currentPart) > 0 {
+				partText := strings.Join(currentPart, "\n")
+				attributes, err := parseAttributes(partText)
+				if err != nil {
+					return nil, err
+				}
+
+				objects = append(objects, Object{Attributes: attributes})
+				currentPart = currentPart[:0] // Clear slice without reallocating.
+			}
 			continue
 		}
 
-		attributes, err := parseAttributes(part)
-		if err != nil {
-			return nil, err
+		// Skip comment lines.
+		line := lines[i]
+		if !strings.HasPrefix(line, "%") && !strings.HasPrefix(line, "#") {
+			currentPart = append(currentPart, line)
 		}
-
-		object := Object{Attributes: attributes}
-		objects = append(objects, object)
 	}
 
 	return objects, nil

--- a/object_test.go
+++ b/object_test.go
@@ -7,9 +7,14 @@ import (
 	"testing"
 )
 
+// Helper function to create string pointer.
+func stringPtr(s string) *string {
+	return &s
+}
+
 func TestObject(t *testing.T) {
-	raw := "organisation:      ORG-CEOf1-RIPE\n" +
-		"description:       CERN"
+	raw := []byte("organisation:      ORG-CEOf1-RIPE\n" +
+		"description:       CERN")
 
 	objects, err := parseObjects(raw)
 	if err != nil {
@@ -26,11 +31,114 @@ func TestObject(t *testing.T) {
 	}
 }
 
-func TestObjectKeys(t *testing.T) {
-	raw := "organisation:      ORG-CEOf1-RIPE\n" +
+func TestObjectLen(t *testing.T) {
+	raw := []byte("organisation:      ORG-CEOf1-RIPE\n" +
 		"remarks:           This is a comment\n" +
 		"description:       CERN\n" +
-		"remarks:           This is another comment"
+		"remarks:           This is another comment")
+
+	objects, err := parseObjects(raw)
+	if err != nil {
+		t.Fatalf(`parseObject => %v`, err)
+	}
+
+	if len(objects) != 1 {
+		t.Fatalf(`parseObject => length of %v, want %v`, len(objects), 1)
+	}
+
+	obj := objects[0]
+	if obj.Len() != 4 {
+		t.Fatalf(`object.Len() => %v, want %v`, obj.Len(), 4)
+	}
+}
+
+func TestGetFirst(t *testing.T) {
+	tests := []struct {
+		name          string
+		object        Object
+		key           string
+		expectedValue *string
+		shouldBeNil   bool
+	}{
+		{
+			name: "KeyExistsOnce",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:           "person",
+			expectedValue: stringPtr("John Doe"),
+		},
+		{
+			name: "KeyExistsMultipleTimes",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "remarks", Value: "Remark 1"},
+					{Name: "remarks", Value: "Remark 2"},
+				},
+			},
+			key:           "remarks",
+			expectedValue: stringPtr("Remark 1"),
+		},
+		{
+			name: "CaseInsensitiveMatch",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:           "ADDRESS",
+			expectedValue: stringPtr("123 Main St"),
+		},
+		{
+			name: "KeyDoesNotExist",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:         "phone",
+			shouldBeNil: true,
+		},
+		{
+			name: "EmptyObject",
+			object: Object{
+				Attributes: []Attribute{},
+			},
+			key:         "person",
+			shouldBeNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.object.GetFirst(tc.key)
+
+			if tc.shouldBeNil {
+				if result != nil {
+					t.Errorf("Expected nil result, but got %v", *result)
+				}
+			} else {
+				if result == nil {
+					t.Errorf("Expected non-nil result, but got nil")
+				} else if *result != *tc.expectedValue {
+					t.Errorf("Result = %q, want %q", *result, *tc.expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestObjectKeys(t *testing.T) {
+	raw := []byte("organisation:      ORG-CEOf1-RIPE\n" +
+		"remarks:           This is a comment\n" +
+		"description:       CERN\n" +
+		"remarks:           This is another comment")
 
 	objects, err := parseObjects(raw)
 	if err != nil {
@@ -60,119 +168,11 @@ func TestObjectKeys(t *testing.T) {
 	}
 }
 
-func TestObjectLen(t *testing.T) {
-	raw := "organisation:      ORG-CEOf1-RIPE\n" +
-		"remarks:           This is a comment\n" +
-		"description:       CERN\n" +
-		"remarks:           This is another comment"
-
-	objects, err := parseObjects(raw)
-	if err != nil {
-		t.Fatalf(`parseObject => %v`, err)
-	}
-
-	if len(objects) != 1 {
-		t.Fatalf(`parseObject => length of %v, want %v`, len(objects), 1)
-	}
-
-	obj := objects[0]
-	if obj.Len() != 4 {
-		t.Fatalf(`object.Len() => %v, want %v`, obj.Len(), 4)
-	}
-}
-
-func TestObjectGetFirst(t *testing.T) {
-	// Helper function for string pointer.
-	stringPtr := func(s string) *string {
-		return &s
-	}
-
-	tests := []struct {
-		name       string
-		attributes []Attribute
-		key        string
-		want       *string
-	}{
-		{
-			name: "MatchFirstAttribute",
-			attributes: []Attribute{
-				{Name: "source", Value: "RIPE"},
-				{Name: "admin-c", Value: "ABC123"},
-			},
-			key:  "source",
-			want: stringPtr("RIPE"),
-		},
-		{
-			name: "MatchSecondAttribute",
-			attributes: []Attribute{
-				{Name: "origin", Value: "AS1234"},
-				{Name: "source", Value: "RIPE"},
-			},
-			key:  "source",
-			want: stringPtr("RIPE"),
-		},
-		{
-			name: "CaseInsensitiveKeyMatch",
-			attributes: []Attribute{
-				{Name: "source", Value: "RIPE"},
-			},
-			key:  "SOURCE",
-			want: stringPtr("RIPE"),
-		},
-		{
-			name: "MultipleAttributesWithSameKey",
-			attributes: []Attribute{
-				{Name: "remarks", Value: "First remark"},
-				{Name: "remarks", Value: "Second remark"},
-			},
-			key:  "remarks",
-			want: stringPtr("First remark"),
-		},
-		{
-			name:       "EmptyAttributes",
-			attributes: []Attribute{},
-			key:        "source",
-			want:       nil,
-		},
-		{
-			name: "KeyNotFound",
-			attributes: []Attribute{
-				{Name: "source", Value: "RIPE"},
-				{Name: "admin-c", Value: "ABC123"},
-			},
-			key:  "origin",
-			want: nil,
-		},
-		{
-			name: "EmptyValue",
-			attributes: []Attribute{
-				{Name: "remarks", Value: ""},
-			},
-			key:  "remarks",
-			want: stringPtr(""),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			o := &Object{Attributes: tt.attributes}
-
-			got := o.GetFirst(tt.key)
-
-			if (got == nil && tt.want != nil) || (got != nil && tt.want == nil) {
-				t.Errorf("GetFirst(%q) = %v, want %v", tt.key, got, tt.want)
-			} else if got != nil && tt.want != nil && *got != *tt.want {
-				t.Errorf("GetFirst(%q) = %q, want %q", tt.key, *got, *tt.want)
-			}
-		})
-	}
-}
-
 func TestObjectGetAll(t *testing.T) {
-	raw := "organisation:      ORG-CEOf1-RIPE\n" +
+	raw := []byte("organisation:      ORG-CEOf1-RIPE\n" +
 		"remarks:           This is a comment\n" +
 		"description:       CERN\n" +
-		"remarks:           This is another comment"
+		"remarks:           This is another comment")
 
 	objects, err := parseObjects(raw)
 	if err != nil {
@@ -217,7 +217,7 @@ func TestObjectGetAll(t *testing.T) {
 }
 
 func TestMultipleObjects(t *testing.T) {
-	raw := "" +
+	data := []byte("" +
 		"poem:           POEM-LIR\n" +
 		"form:           FORM-HAIKU\n" +
 		"text:           hello ripe please\n" +
@@ -239,9 +239,9 @@ func TestMultipleObjects(t *testing.T) {
 		"mnt-by:         dummy-mnt\n" +
 		"created:        2024-06-01T23:28:08Z\n" +
 		"last-modified:  2024-06-01T23:28:08Z\n" +
-		"source:         RIPE\n"
+		"source:         RIPE\n")
 
-	objects, err := parseObjects(raw)
+	objects, err := parseObjects(data)
 	if err != nil {
 		t.Fatalf("(error): %v", err)
 	}
@@ -256,5 +256,377 @@ func TestMultipleObjects(t *testing.T) {
 
 	if objects[1].Len() != 11 {
 		t.Fatalf("(1.length): got %v, want %v", objects[1].Len(), 11)
+	}
+}
+
+func TestObjectString(t *testing.T) {
+	tests := []struct {
+		name     string
+		object   Object
+		expected string
+	}{
+		{
+			name: "EmptyObject",
+			object: Object{
+				Attributes: []Attribute{},
+			},
+			expected: "",
+		},
+		{
+			name: "SingleAttribute",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+				},
+			},
+			expected: "person:John Doe",
+		},
+		{
+			name: "MultipleAttributes",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+					{Name: "phone", Value: "+1-555-1234"},
+				},
+			},
+			expected: "person:John Doe\naddress:123 Main St\nphone:+1-555-1234",
+		},
+		{
+			name: "DuplicateAttributes",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "remarks", Value: "Remark 1"},
+					{Name: "remarks", Value: "Remark 2"},
+				},
+			},
+			expected: "person:John Doe\nremarks:Remark 1\nremarks:Remark 2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.object.String()
+			if result != tc.expected {
+				t.Errorf("Object.String() = %q, want %q", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestEnsureClass(t *testing.T) {
+	tests := []struct {
+		name      string
+		object    Object
+		class     string
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "CorrectClass",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			class:     "person",
+			expectErr: false,
+		},
+		{
+			name: "CaseInsensitiveMatch",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			class:     "PERSON",
+			expectErr: false,
+		},
+		{
+			name: "IncorrectClass",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "route", Value: "192.168.0.0/16"},
+					{Name: "origin", Value: "AS12345"},
+				},
+			},
+			class:     "person",
+			expectErr: true,
+			errMsg:    "attribute 'person' should be the first, but found 'route' instead",
+		},
+		{
+			name: "EmptyObject",
+			object: Object{
+				Attributes: []Attribute{},
+			},
+			class:     "person",
+			expectErr: true,
+			errMsg:    "object has no attributes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.object.EnsureClass(tc.class)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if err.Error() != tc.errMsg {
+					t.Errorf("Error message = %q, want %q", err.Error(), tc.errMsg)
+				}
+			} else if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnsureAtLeastOne(t *testing.T) {
+	tests := []struct {
+		name      string
+		object    Object
+		key       string
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "KeyExistsOnce",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "address",
+			expectErr: false,
+		},
+		{
+			name: "KeyExistsMultipleTimes",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "remarks", Value: "Remark 1"},
+					{Name: "remarks", Value: "Remark 2"},
+				},
+			},
+			key:       "remarks",
+			expectErr: false,
+		},
+		{
+			name: "CaseInsensitiveMatch",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "ADDRESS",
+			expectErr: false,
+		},
+		{
+			name: "KeyDoesNotExist",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "phone",
+			expectErr: true,
+			errMsg:    "attribute 'phone' is (mandatory, multiple) but found none",
+		},
+		{
+			name: "EmptyObject",
+			object: Object{
+				Attributes: []Attribute{},
+			},
+			key:       "person",
+			expectErr: true,
+			errMsg:    "attribute 'person' is (mandatory, multiple) but found none",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.object.EnsureAtLeastOne(tc.key)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if err.Error() != tc.errMsg {
+					t.Errorf("Error message = %q, want %q", err.Error(), tc.errMsg)
+				}
+			} else if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnsureAtMostOne(t *testing.T) {
+	tests := []struct {
+		name      string
+		object    Object
+		key       string
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "KeyDoesNotExist",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "phone",
+			expectErr: false,
+		},
+		{
+			name: "KeyExistsOnce",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "address",
+			expectErr: false,
+		},
+		{
+			name: "CaseInsensitiveMatch",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "ADDRESS",
+			expectErr: false,
+		},
+		{
+			name: "KeyExistsMultipleTimes",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "remarks", Value: "Remark 1"},
+					{Name: "remarks", Value: "Remark 2"},
+				},
+			},
+			key:       "remarks",
+			expectErr: true,
+			errMsg:    "attribute 'remarks' is (optional, single) but found multiple",
+		},
+		{
+			name: "EmptyObject",
+			object: Object{
+				Attributes: []Attribute{},
+			},
+			key:       "person",
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.object.EnsureAtMostOne(tc.key)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if err.Error() != tc.errMsg {
+					t.Errorf("Error message = %q, want %q", err.Error(), tc.errMsg)
+				}
+			} else if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnsureOne(t *testing.T) {
+	tests := []struct {
+		name      string
+		object    Object
+		key       string
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "KeyExistsOnce",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "address",
+			expectErr: false,
+		},
+		{
+			name: "CaseInsensitiveMatch",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "ADDRESS",
+			expectErr: false,
+		},
+		{
+			name: "KeyDoesNotExist",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "address", Value: "123 Main St"},
+				},
+			},
+			key:       "phone",
+			expectErr: true,
+			errMsg:    "attribute 'phone' is (mandatory, single) but found none",
+		},
+		{
+			name: "KeyExistsMultipleTimes",
+			object: Object{
+				Attributes: []Attribute{
+					{Name: "person", Value: "John Doe"},
+					{Name: "remarks", Value: "Remark 1"},
+					{Name: "remarks", Value: "Remark 2"},
+				},
+			},
+			key:       "remarks",
+			expectErr: true,
+			errMsg:    "attribute 'remarks' is (mandatory, single) but found multiple",
+		},
+		{
+			name: "EmptyObject",
+			object: Object{
+				Attributes: []Attribute{},
+			},
+			key:       "person",
+			expectErr: true,
+			errMsg:    "attribute 'person' is (mandatory, single) but found none",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.object.EnsureOne(tc.key)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if err.Error() != tc.errMsg {
+					t.Errorf("Error message = %q, want %q", err.Error(), tc.errMsg)
+				}
+			} else if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/object_test.go
+++ b/object_test.go
@@ -4,6 +4,7 @@
 package rpsl
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -16,7 +17,7 @@ func TestObject(t *testing.T) {
 	raw := []byte("organisation:      ORG-CEOf1-RIPE\n" +
 		"description:       CERN")
 
-	objects, err := parseObjects(raw)
+	objects, err := parseObjects(bytes.NewReader(raw))
 	if err != nil {
 		t.Fatalf(`parseObject => %v`, err)
 	}
@@ -37,7 +38,7 @@ func TestObjectLen(t *testing.T) {
 		"description:       CERN\n" +
 		"remarks:           This is another comment")
 
-	objects, err := parseObjects(raw)
+	objects, err := parseObjects(bytes.NewReader(raw))
 	if err != nil {
 		t.Fatalf(`parseObject => %v`, err)
 	}
@@ -140,7 +141,7 @@ func TestObjectKeys(t *testing.T) {
 		"description:       CERN\n" +
 		"remarks:           This is another comment")
 
-	objects, err := parseObjects(raw)
+	objects, err := parseObjects(bytes.NewReader(raw))
 	if err != nil {
 		t.Fatalf(`parseObject => %v`, err)
 	}
@@ -174,7 +175,7 @@ func TestObjectGetAll(t *testing.T) {
 		"description:       CERN\n" +
 		"remarks:           This is another comment")
 
-	objects, err := parseObjects(raw)
+	objects, err := parseObjects(bytes.NewReader(raw))
 	if err != nil {
 		t.Fatalf(`parseObject => %v`, err)
 	}
@@ -241,7 +242,7 @@ func TestMultipleObjects(t *testing.T) {
 		"last-modified:  2024-06-01T23:28:08Z\n" +
 		"source:         RIPE\n")
 
-	objects, err := parseObjects(data)
+	objects, err := parseObjects(bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("(error): %v", err)
 	}

--- a/object_test.go
+++ b/object_test.go
@@ -26,27 +26,6 @@ func TestObject(t *testing.T) {
 	}
 }
 
-func TestObjectLen(t *testing.T) {
-	raw := "organisation:      ORG-CEOf1-RIPE\n" +
-		"remarks:           This is a comment\n" +
-		"description:       CERN\n" +
-		"remarks:           This is another comment"
-
-	objects, err := parseObjects(raw)
-	if err != nil {
-		t.Fatalf(`parseObject => %v`, err)
-	}
-
-	if len(objects) != 1 {
-		t.Fatalf(`parseObject => length of %v, want %v`, len(objects), 1)
-	}
-
-	obj := objects[0]
-	if obj.Len() != 4 {
-		t.Fatalf(`object.Len() => %v, want %v`, obj.Len(), 4)
-	}
-}
-
 func TestObjectKeys(t *testing.T) {
 	raw := "organisation:      ORG-CEOf1-RIPE\n" +
 		"remarks:           This is a comment\n" +
@@ -78,6 +57,114 @@ func TestObjectKeys(t *testing.T) {
 
 	if keys[2] != "description" {
 		t.Fatalf(`object.Keys()[2] => %v, want %v`, keys[2], "description")
+	}
+}
+
+func TestObjectLen(t *testing.T) {
+	raw := "organisation:      ORG-CEOf1-RIPE\n" +
+		"remarks:           This is a comment\n" +
+		"description:       CERN\n" +
+		"remarks:           This is another comment"
+
+	objects, err := parseObjects(raw)
+	if err != nil {
+		t.Fatalf(`parseObject => %v`, err)
+	}
+
+	if len(objects) != 1 {
+		t.Fatalf(`parseObject => length of %v, want %v`, len(objects), 1)
+	}
+
+	obj := objects[0]
+	if obj.Len() != 4 {
+		t.Fatalf(`object.Len() => %v, want %v`, obj.Len(), 4)
+	}
+}
+
+func TestObjectGetFirst(t *testing.T) {
+	// Helper function for string pointer.
+	stringPtr := func(s string) *string {
+		return &s
+	}
+
+	tests := []struct {
+		name       string
+		attributes []Attribute
+		key        string
+		want       *string
+	}{
+		{
+			name: "MatchFirstAttribute",
+			attributes: []Attribute{
+				{Name: "source", Value: "RIPE"},
+				{Name: "admin-c", Value: "ABC123"},
+			},
+			key:  "source",
+			want: stringPtr("RIPE"),
+		},
+		{
+			name: "MatchSecondAttribute",
+			attributes: []Attribute{
+				{Name: "origin", Value: "AS1234"},
+				{Name: "source", Value: "RIPE"},
+			},
+			key:  "source",
+			want: stringPtr("RIPE"),
+		},
+		{
+			name: "CaseInsensitiveKeyMatch",
+			attributes: []Attribute{
+				{Name: "source", Value: "RIPE"},
+			},
+			key:  "SOURCE",
+			want: stringPtr("RIPE"),
+		},
+		{
+			name: "MultipleAttributesWithSameKey",
+			attributes: []Attribute{
+				{Name: "remarks", Value: "First remark"},
+				{Name: "remarks", Value: "Second remark"},
+			},
+			key:  "remarks",
+			want: stringPtr("First remark"),
+		},
+		{
+			name:       "EmptyAttributes",
+			attributes: []Attribute{},
+			key:        "source",
+			want:       nil,
+		},
+		{
+			name: "KeyNotFound",
+			attributes: []Attribute{
+				{Name: "source", Value: "RIPE"},
+				{Name: "admin-c", Value: "ABC123"},
+			},
+			key:  "origin",
+			want: nil,
+		},
+		{
+			name: "EmptyValue",
+			attributes: []Attribute{
+				{Name: "remarks", Value: ""},
+			},
+			key:  "remarks",
+			want: stringPtr(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &Object{Attributes: tt.attributes}
+
+			got := o.GetFirst(tt.key)
+
+			if (got == nil && tt.want != nil) || (got != nil && tt.want == nil) {
+				t.Errorf("GetFirst(%q) = %v, want %v", tt.key, got, tt.want)
+			} else if got != nil && tt.want != nil && *got != *tt.want {
+				t.Errorf("GetFirst(%q) = %q, want %q", tt.key, *got, *tt.want)
+			}
+		})
 	}
 }
 
@@ -130,7 +217,7 @@ func TestObjectGetAll(t *testing.T) {
 }
 
 func TestMultipleObjects(t *testing.T) {
-	data := "" +
+	raw := "" +
 		"poem:           POEM-LIR\n" +
 		"form:           FORM-HAIKU\n" +
 		"text:           hello ripe please\n" +
@@ -154,7 +241,7 @@ func TestMultipleObjects(t *testing.T) {
 		"last-modified:  2024-06-01T23:28:08Z\n" +
 		"source:         RIPE\n"
 
-	objects, err := parseObjects(data)
+	objects, err := parseObjects(raw)
 	if err != nil {
 		t.Fatalf("(error): %v", err)
 	}

--- a/rpsl.go
+++ b/rpsl.go
@@ -3,7 +3,11 @@
 
 package rpsl
 
-import "errors"
+import (
+	"errors"
+	"io"
+	"strings"
+)
 
 // Parse parses a string containing a single RPSL object
 // and returns a representation of the parsed data.
@@ -26,31 +30,29 @@ import "errors"
 //
 //	fmt.Printf("Parsed Object: %+v\n", obj)
 func Parse(raw string) (*Object, error) {
-	return ParseBytes([]byte(raw))
+	return ParseFromReader(strings.NewReader(raw))
 }
 
-// ParseBytes parses a byte slice containing a single RPSL object
-// and returns a representation of the parsed data.
-// If the byte slice contains multiple objects, an error will be returned.
-// If the byte slice is empty, an error will be returned.
+// ParseFromReader parses an RPSL object from an io.Reader and returns a representation of the parsed data.
+// If the reader contains multiple objects, an error will be returned.
+// If the reader is empty, an error will be returned.
 //
 // Example:
 //
-//	raw := []byte("person:	John Doe\n"+
-//	    "address:	1234 Elm Street\n"+
-//	    "phone:		+1 555 123456\n"+
-//	    "nic-hdl:	JD1234-RIPE\n"+
-//	    "mnt-by:	EXAMPLE-MNT\n"+
-//	    "source:	RIPE\n")
-//	obj, err := ParseBytes(raw)
+//	file, err := os.Open("rpsl_object.txt")
+//	if err != nil {
+//	    log.Fatalf("Failed to open file: %v", err)
+//	}
+//	defer file.Close()
 //
+//	obj, err := ParseFromReader(file)
 //	if err != nil {
 //	    log.Fatalf("Failed to parse RPSL object: %v", err)
 //	}
 //
 //	fmt.Printf("Parsed Object: %+v\n", obj)
-func ParseBytes(raw []byte) (*Object, error) {
-	objects, err := parseObjects(raw)
+func ParseFromReader(r io.Reader) (*Object, error) {
+	objects, err := parseObjects(r)
 	if err != nil {
 		return nil, err
 	}
@@ -95,39 +97,30 @@ func ParseBytes(raw []byte) (*Object, error) {
 //		fmt.Printf("Parsed Object: %+v\n", obj)
 //	}
 func ParseMany(raw string) ([]Object, error) {
-	return ParseManyBytes([]byte(raw))
+	return ParseManyFromReader(strings.NewReader(raw))
 }
 
-// ParseManyBytes parses a byte slice containing multiple RPSL objects
-// and returns a representation of the parsed data.
-// If the byte slice does not contain any objects, nil will be returned.
+// ParseManyFromReader parses multiple RPSL objects from an io.Reader and returns a representation of the parsed data.
+// If the reader does not contain any objects, nil will be returned.
 //
 // Example:
 //
-//	raw := []byte("person:	John Doe\n"+
-//		"address:	1234 Elm Street\n"+
-//		"phone:		+1 555 123456\n"+
-//		"nic-hdl:	JD1234-RIPE\n"+
-//		"mnt-by:	EXAMPLE-MNT\n"+
-//		"source:	RIPE\n"+
-//		"\n"+ // Objects are delimited by one or more empty lines
-//		"person:	Jane Smith\n"+
-//		"address:	5678 Oak Street\n"+
-//		"phone:		+1 555 654321\n"+
-//		"nic-hdl:	JS5678-RIPE\n"+
-//		"mnt-by:	EXAMPLE-MNT\n"+
-//		"source:	RIPE")
-//	objs, err := ParseManyBytes(raw)
-//
+//	file, err := os.Open("rpsl_objects.txt")
 //	if err != nil {
-//		log.Fatalf("Failed to parse RPSL objects: %v", err)
+//	    log.Fatalf("Failed to open file: %v", err)
+//	}
+//	defer file.Close()
+//
+//	objs, err := ParseManyFromReader(file)
+//	if err != nil {
+//	    log.Fatalf("Failed to parse RPSL objects: %v", err)
 //	}
 //
 //	for _, obj := range objs {
-//		fmt.Printf("Parsed Object: %+v\n", obj)
+//	    fmt.Printf("Parsed Object: %+v\n", obj)
 //	}
-func ParseManyBytes(raw []byte) ([]Object, error) {
-	objects, err := parseObjects(raw)
+func ParseManyFromReader(r io.Reader) ([]Object, error) {
+	objects, err := parseObjects(r)
 	if err != nil {
 		return nil, err
 	}

--- a/rpsl.go
+++ b/rpsl.go
@@ -3,10 +3,7 @@
 
 package rpsl
 
-import (
-	"errors"
-	"io"
-)
+import "errors"
 
 // Parse parses a string containing a single RPSL object
 // and returns a representation of the parsed data.
@@ -29,6 +26,30 @@ import (
 //
 //	fmt.Printf("Parsed Object: %+v\n", obj)
 func Parse(raw string) (*Object, error) {
+	return ParseBytes([]byte(raw))
+}
+
+// ParseBytes parses a byte slice containing a single RPSL object
+// and returns a representation of the parsed data.
+// If the byte slice contains multiple objects, an error will be returned.
+// If the byte slice is empty, an error will be returned.
+//
+// Example:
+//
+//	raw := []byte("person:	John Doe\n"+
+//	    "address:	1234 Elm Street\n"+
+//	    "phone:		+1 555 123456\n"+
+//	    "nic-hdl:	JD1234-RIPE\n"+
+//	    "mnt-by:	EXAMPLE-MNT\n"+
+//	    "source:	RIPE\n")
+//	obj, err := ParseBytes(raw)
+//
+//	if err != nil {
+//	    log.Fatalf("Failed to parse RPSL object: %v", err)
+//	}
+//
+//	fmt.Printf("Parsed Object: %+v\n", obj)
+func ParseBytes(raw []byte) (*Object, error) {
 	objects, err := parseObjects(raw)
 	if err != nil {
 		return nil, err
@@ -45,7 +66,7 @@ func Parse(raw string) (*Object, error) {
 	return &objects[0], nil
 }
 
-// ParseMany parses a string containing a multiple RPSL object
+// ParseMany parses a string containing multiple RPSL objects
 // and returns a representation of the parsed data.
 // If the string does not contain any objects, nil will be returned.
 //
@@ -64,30 +85,49 @@ func Parse(raw string) (*Object, error) {
 //		"nic-hdl:	JS5678-RIPE\n"+
 //		"mnt-by:	EXAMPLE-MNT\n"+
 //		"source:	RIPE"
-//	obj, err := ParseMany(raw)
+//	objs, err := ParseMany(raw)
 //
 //	if err != nil {
-//		log.Fatalf("Failed to parse RPSL object: %v", err)
+//		log.Fatalf("Failed to parse RPSL objects: %v", err)
 //	}
 //
-//	for _, obj := range *objs {
+//	for _, obj := range objs {
 //		fmt.Printf("Parsed Object: %+v\n", obj)
 //	}
 func ParseMany(raw string) ([]Object, error) {
-	objects, err := parseObjects(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(objects) == 0 {
-		return nil, nil
-	}
-
-	return objects, nil
+	return ParseManyBytes([]byte(raw))
 }
 
-func ParseManyFromReader(r io.Reader) ([]Object, error) {
-	objects, err := parseObjectsFromReader(r)
+// ParseManyBytes parses a byte slice containing multiple RPSL objects
+// and returns a representation of the parsed data.
+// If the byte slice does not contain any objects, nil will be returned.
+//
+// Example:
+//
+//	raw := []byte("person:	John Doe\n"+
+//		"address:	1234 Elm Street\n"+
+//		"phone:		+1 555 123456\n"+
+//		"nic-hdl:	JD1234-RIPE\n"+
+//		"mnt-by:	EXAMPLE-MNT\n"+
+//		"source:	RIPE\n"+
+//		"\n"+ // Objects are delimited by one or more empty lines
+//		"person:	Jane Smith\n"+
+//		"address:	5678 Oak Street\n"+
+//		"phone:		+1 555 654321\n"+
+//		"nic-hdl:	JS5678-RIPE\n"+
+//		"mnt-by:	EXAMPLE-MNT\n"+
+//		"source:	RIPE")
+//	objs, err := ParseManyBytes(raw)
+//
+//	if err != nil {
+//		log.Fatalf("Failed to parse RPSL objects: %v", err)
+//	}
+//
+//	for _, obj := range objs {
+//		fmt.Printf("Parsed Object: %+v\n", obj)
+//	}
+func ParseManyBytes(raw []byte) ([]Object, error) {
+	objects, err := parseObjects(raw)
 	if err != nil {
 		return nil, err
 	}

--- a/rpsl.go
+++ b/rpsl.go
@@ -3,9 +3,11 @@
 
 package rpsl
 
-import "fmt"
+import (
+	"errors"
+)
 
-// Parses a string containing a single RPSL object
+// Parse parses a string containing a single RPSL object
 // and returns a representation of the parsed data.
 // If the string contains multiple objects, an error will be returned.
 // If the string is empty, an error will be returned.
@@ -27,23 +29,22 @@ import "fmt"
 //	fmt.Printf("Parsed Object: %+v\n", obj)
 func Parse(raw string) (*Object, error) {
 	objects, err := parseObjects(raw)
-
 	if err != nil {
 		return nil, err
 	}
 
 	if len(objects) == 0 {
-		return nil, fmt.Errorf("no objects found in input")
+		return nil, errors.New("no objects found in input")
 	}
 
 	if len(objects) > 1 {
-		return nil, fmt.Errorf("multiple objects found in input")
+		return nil, errors.New("multiple objects found in input")
 	}
 
 	return &objects[0], nil
 }
 
-// Parses a string containing a multiple RPSL object
+// ParseMany parses a string containing a multiple RPSL object
 // and returns a representation of the parsed data.
 // If the string does not contain any objects, nil will be returned.
 //
@@ -73,7 +74,6 @@ func Parse(raw string) (*Object, error) {
 //	}
 func ParseMany(raw string) ([]Object, error) {
 	objects, err := parseObjects(raw)
-
 	if err != nil {
 		return nil, err
 	}

--- a/rpsl.go
+++ b/rpsl.go
@@ -5,6 +5,7 @@ package rpsl
 
 import (
 	"errors"
+	"io"
 )
 
 // Parse parses a string containing a single RPSL object
@@ -74,6 +75,19 @@ func Parse(raw string) (*Object, error) {
 //	}
 func ParseMany(raw string) ([]Object, error) {
 	objects, err := parseObjects(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(objects) == 0 {
+		return nil, nil
+	}
+
+	return objects, nil
+}
+
+func ParseManyFromReader(r io.Reader) ([]Object, error) {
+	objects, err := parseObjectsFromReader(r)
 	if err != nil {
 		return nil, err
 	}

--- a/rpsl_test.go
+++ b/rpsl_test.go
@@ -22,7 +22,6 @@ func TestIntegration(t *testing.T) {
 	for _, dataset := range datasets {
 		t.Run(dataset, func(t *testing.T) {
 			data, err := os.ReadFile("tests/data/" + dataset)
-
 			if err != nil {
 				t.Fatalf("unable to read file: %v", err)
 			}

--- a/rpsl_test.go
+++ b/rpsl_test.go
@@ -43,7 +43,7 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestParseAPI(t *testing.T) {
-	// Test the string-based Parse function (original API)
+	// Test the string-based Parse function (original API).
 	rawString := "person: John Doe\naddress: 123 Example St\nnic-hdl: JD1-RIPE\nsource: RIPE"
 	obj, err := Parse(rawString)
 	if err != nil {
@@ -58,7 +58,7 @@ func TestParseAPI(t *testing.T) {
 		t.Fatalf("Parse(string) object length: got %v, want 4", obj.Len())
 	}
 
-	// Test the byte-based ParseFromBytes function (new API)
+	// Test the byte-based ParseFromBytes function (new API).
 	rawBytes := bytes.NewReader([]byte("person: Jane Smith\naddress: 456 Example Ave\nnic-hdl: JS1-RIPE\nsource: RIPE"))
 	obj, err = ParseFromReader(rawBytes)
 	if err != nil {
@@ -75,7 +75,7 @@ func TestParseAPI(t *testing.T) {
 }
 
 func TestParseManyAPI(t *testing.T) {
-	// Test the string-based ParseMany function (original API)
+	// Test the string-based ParseMany function (original API).
 	rawString := "person: John Doe\naddress: 123 Example St\nnic-hdl: JD1-RIPE\nsource: RIPE\n\nperson: Jane Smith\naddress: 456 Example Ave\nnic-hdl: JS1-RIPE\nsource: RIPE"
 	objects, err := ParseMany(rawString)
 	if err != nil {
@@ -86,7 +86,7 @@ func TestParseManyAPI(t *testing.T) {
 		t.Fatalf("ParseMany(string) objects count: got %v, want 2", len(objects))
 	}
 
-	// Test the byte-based ParseManyFromBytes function (new API)
+	// Test the byte-based ParseManyFromBytes function (new API).
 	rawBytes := bytes.NewReader([]byte("person: Alice Brown\naddress: 789 Example Blvd\nnic-hdl: AB1-RIPE\nsource: RIPE\n\nperson: Bob Green\naddress: 101 Example Ct\nnic-hdl: BG1-RIPE\nsource: RIPE"))
 	objects, err = ParseManyFromReader(rawBytes)
 	if err != nil {
@@ -132,10 +132,12 @@ func TestParse(t *testing.T) {
 				if obj.Len() != 4 {
 					return errors.New("expected 4 attributes")
 				}
+
 				person := obj.GetFirst("person")
 				if person == nil || *person != "John Doe" {
 					return errors.New("person attribute incorrect")
 				}
+
 				return nil
 			},
 		},
@@ -162,10 +164,12 @@ func TestParse(t *testing.T) {
 				if obj.Len() != 3 {
 					return errors.New("expected 3 attributes")
 				}
+
 				address := obj.GetFirst("address")
 				if address == nil || *address != "123 Main St" {
 					return errors.New("address attribute incorrect")
 				}
+
 				return nil
 			},
 		},
@@ -182,10 +186,12 @@ func TestParse(t *testing.T) {
 				if obj == nil {
 					return errors.New("object is nil")
 				}
+
 				remarks := obj.GetFirst("remarks")
 				if remarks == nil || *remarks != "First line Continuation line 1 Continuation line 2" {
 					return errors.New("remarks with continuation lines incorrect")
 				}
+
 				return nil
 			},
 		},
@@ -201,10 +207,12 @@ func TestParse(t *testing.T) {
 				if obj == nil {
 					return errors.New("object is nil")
 				}
+
 				address := obj.GetFirst("address")
 				if address == nil || *address != "123 Main St Suite 100" {
 					return errors.New("address with plus notation incorrect")
 				}
+
 				return nil
 			},
 		},
@@ -213,8 +221,6 @@ func TestParse(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj, err := Parse(tc.input)
-
-			// Check error expectations
 			if tc.expectErr {
 				if err == nil {
 					t.Errorf("Expected error but got nil")
@@ -224,13 +230,11 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			// No error expected
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 				return
 			}
 
-			// Validate object
 			if tc.validateObj != nil {
 				if err = tc.validateObj(obj); err != nil {
 					t.Errorf("Object validation failed: %v", err)
@@ -327,7 +331,6 @@ func TestParseMany(t *testing.T) {
 					return errors.New("expected 3 objects")
 				}
 
-				// Check third object
 				person3 := objs[2].GetFirst("person")
 				if person3 == nil || *person3 != "Bob Johnson" {
 					return errors.New("third person attribute incorrect")
@@ -340,7 +343,7 @@ func TestParseMany(t *testing.T) {
 			name: "ObjectsWithMultipleEmptyLinesBetween",
 			input: "person:  John Doe\n" +
 				"source:  TEST\n" +
-				"\n\n\n" + // Multiple empty lines
+				"\n\n\n" +
 				"person:  Jane Smith\n" +
 				"source:  TEST",
 			expectErr:     false,
@@ -351,8 +354,6 @@ func TestParseMany(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			objs, err := ParseMany(tc.input)
-
-			// Check error expectations
 			if tc.expectErr {
 				if err == nil {
 					t.Errorf("Expected error but got nil")
@@ -362,13 +363,11 @@ func TestParseMany(t *testing.T) {
 				return
 			}
 
-			// No error expected
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 				return
 			}
 
-			// Check if nil is returned for empty input
 			if tc.expectedCount == 0 {
 				if objs != nil {
 					t.Errorf("Expected nil objects for empty input, got %v objects", len(objs))
@@ -376,13 +375,11 @@ func TestParseMany(t *testing.T) {
 				return
 			}
 
-			// Check object count
 			if len(objs) != tc.expectedCount {
 				t.Errorf("Expected %d objects, got %d", tc.expectedCount, len(objs))
 				return
 			}
 
-			// Validate objects
 			if tc.validateObjs != nil {
 				if err = tc.validateObjs(objs); err != nil {
 					t.Errorf("Objects validation failed: %v", err)
@@ -491,7 +488,7 @@ func TestParseManyFromReader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			objs, err := parseObjects(bytes.NewReader(tc.input))
 
-			// Check error expectations
+			// Check error expectations.
 			if tc.expectErr {
 				if err == nil {
 					t.Errorf("Expected error but got nil")

--- a/rpsl_test.go
+++ b/rpsl_test.go
@@ -4,7 +4,9 @@
 package rpsl
 
 import (
+	"errors"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -26,14 +28,624 @@ func TestIntegration(t *testing.T) {
 				t.Fatalf("unable to read file: %v", err)
 			}
 
-			objects, err := parseObjects(string(data))
+			objects, err := ParseManyBytes(data)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			if len(objects) == 0 {
-				t.Fatalf(`parseObjects => length of %v, want %v`, len(objects), 0)
+				t.Fatalf(`parseObjects => length of %v, want > 0`, len(objects))
 			}
 		})
+	}
+}
+
+func TestParseAPI(t *testing.T) {
+	// Test the string-based Parse function (original API)
+	rawString := "person: John Doe\naddress: 123 Example St\nnic-hdl: JD1-RIPE\nsource: RIPE"
+	obj, err := Parse(rawString)
+	if err != nil {
+		t.Fatalf("Parse(string) error: %v", err)
+	}
+
+	if obj == nil {
+		t.Fatalf("Parse(string) returned nil object")
+	}
+
+	if obj.Len() != 4 {
+		t.Fatalf("Parse(string) object length: got %v, want 4", obj.Len())
+	}
+
+	// Test the byte-based ParseBytes function (new API)
+	rawBytes := []byte("person: Jane Smith\naddress: 456 Example Ave\nnic-hdl: JS1-RIPE\nsource: RIPE")
+	obj, err = ParseBytes(rawBytes)
+	if err != nil {
+		t.Fatalf("ParseBytes error: %v", err)
+	}
+
+	if obj == nil {
+		t.Fatalf("ParseBytes returned nil object")
+	}
+
+	if obj.Len() != 4 {
+		t.Fatalf("ParseBytes object length: got %v, want 4", obj.Len())
+	}
+}
+
+func TestParseManyAPI(t *testing.T) {
+	// Test the string-based ParseMany function (original API)
+	rawString := "person: John Doe\naddress: 123 Example St\nnic-hdl: JD1-RIPE\nsource: RIPE\n\nperson: Jane Smith\naddress: 456 Example Ave\nnic-hdl: JS1-RIPE\nsource: RIPE"
+	objects, err := ParseMany(rawString)
+	if err != nil {
+		t.Fatalf("ParseMany(string) error: %v", err)
+	}
+
+	if len(objects) != 2 {
+		t.Fatalf("ParseMany(string) objects count: got %v, want 2", len(objects))
+	}
+
+	// Test the byte-based ParseManyBytes function (new API)
+	rawBytes := []byte("person: Alice Brown\naddress: 789 Example Blvd\nnic-hdl: AB1-RIPE\nsource: RIPE\n\nperson: Bob Green\naddress: 101 Example Ct\nnic-hdl: BG1-RIPE\nsource: RIPE")
+	objects, err = ParseManyBytes(rawBytes)
+	if err != nil {
+		t.Fatalf("ParseManyBytes error: %v", err)
+	}
+
+	if len(objects) != 2 {
+		t.Fatalf("ParseManyBytes objects count: got %v, want 2", len(objects))
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectErr    bool
+		errSubstring string
+		validateObj  func(*Object) error
+	}{
+		{
+			name:         "EmptyInput",
+			input:        "",
+			expectErr:    true,
+			errSubstring: "no objects found",
+		},
+		{
+			name:         "InvalidSyntax",
+			input:        "this is not a valid RPSL object",
+			expectErr:    true,
+			errSubstring: "parseKey: illegal character",
+		},
+		{
+			name: "SingleObject",
+			input: "person:  John Doe\n" +
+				"address: 123 Main St\n" +
+				"phone:   +1-555-1234\n" +
+				"source:  TEST",
+			expectErr: false,
+			validateObj: func(obj *Object) error {
+				if obj == nil {
+					return errors.New("object is nil")
+				}
+				if obj.Len() != 4 {
+					return errors.New("expected 4 attributes")
+				}
+				person := obj.GetFirst("person")
+				if person == nil || *person != "John Doe" {
+					return errors.New("person attribute incorrect")
+				}
+				return nil
+			},
+		},
+		{
+			name: "MultipleObjects",
+			input: "person:  John Doe\n" +
+				"source:  TEST\n" +
+				"\n" +
+				"person:  Jane Smith\n" +
+				"source:  TEST",
+			expectErr:    true,
+			errSubstring: "multiple objects found",
+		},
+		{
+			name: "ObjectWithComments",
+			input: "person:  John Doe # Inline comment\n" +
+				"address: 123 Main St\n" +
+				"source:  TEST",
+			expectErr: false,
+			validateObj: func(obj *Object) error {
+				if obj == nil {
+					return errors.New("object is nil")
+				}
+				if obj.Len() != 3 {
+					return errors.New("expected 3 attributes")
+				}
+				address := obj.GetFirst("address")
+				if address == nil || *address != "123 Main St" {
+					return errors.New("address attribute incorrect")
+				}
+				return nil
+			},
+		},
+		{
+			name: "ObjectWithContinuationLines",
+			input: "person:  John Doe\n" +
+				"address: 123 Main St\n" +
+				"remarks: First line\n" +
+				" Continuation line 1\n" +
+				" Continuation line 2\n" +
+				"source:  TEST",
+			expectErr: false,
+			validateObj: func(obj *Object) error {
+				if obj == nil {
+					return errors.New("object is nil")
+				}
+				remarks := obj.GetFirst("remarks")
+				if remarks == nil || *remarks != "First line Continuation line 1 Continuation line 2" {
+					return errors.New("remarks with continuation lines incorrect")
+				}
+				return nil
+			},
+		},
+		{
+			name: "ObjectWithPlusNotation",
+			input: "person:  John Doe\n" +
+				"address: \n" +
+				"+123 Main St\n" +
+				"+Suite 100\n" +
+				"source:  TEST",
+			expectErr: false,
+			validateObj: func(obj *Object) error {
+				if obj == nil {
+					return errors.New("object is nil")
+				}
+				address := obj.GetFirst("address")
+				if address == nil || *address != "123 Main St Suite 100" {
+					return errors.New("address with plus notation incorrect")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, err := Parse(tc.input)
+
+			// Check error expectations
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if tc.errSubstring != "" && !strings.Contains(err.Error(), tc.errSubstring) {
+					t.Errorf("Error %q does not contain expected substring %q", err.Error(), tc.errSubstring)
+				}
+				return
+			}
+
+			// No error expected
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Validate object
+			if tc.validateObj != nil {
+				if err = tc.validateObj(obj); err != nil {
+					t.Errorf("Object validation failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestParseBytes(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []byte
+		expectErr    bool
+		errSubstring string
+		validateObj  func(*Object) error
+	}{
+		{
+			name:         "EmptyInput",
+			input:        []byte{},
+			expectErr:    true,
+			errSubstring: "no objects found",
+		},
+		{
+			name:         "NilInput",
+			input:        nil,
+			expectErr:    true,
+			errSubstring: "no objects found",
+		},
+		{
+			name:         "InvalidSyntax",
+			input:        []byte("this is not a valid RPSL object"),
+			expectErr:    true,
+			errSubstring: "parseKey: illegal character",
+		},
+		{
+			name: "SingleObject",
+			input: []byte("person:  John Doe\n" +
+				"address: 123 Main St\n" +
+				"phone:   +1-555-1234\n" +
+				"source:  TEST"),
+			expectErr: false,
+			validateObj: func(obj *Object) error {
+				if obj == nil {
+					return errors.New("object is nil")
+				}
+				if obj.Len() != 4 {
+					return errors.New("expected 4 attributes")
+				}
+				phone := obj.GetFirst("phone")
+				if phone == nil || *phone != "+1-555-1234" {
+					return errors.New("phone attribute incorrect")
+				}
+				return nil
+			},
+		},
+		{
+			name: "ObjectWithSpecialCharacters",
+			input: []byte("person:  Jöhn Døe\n" +
+				"address: 123 Élm Straße\n" +
+				"source:  TEST"),
+			expectErr: false,
+			validateObj: func(obj *Object) error {
+				if obj == nil {
+					return errors.New("object is nil")
+				}
+				person := obj.GetFirst("person")
+				if person == nil || *person != "Jöhn Døe" {
+					return errors.New("person attribute with special chars incorrect")
+				}
+				address := obj.GetFirst("address")
+				if address == nil || *address != "123 Élm Straße" {
+					return errors.New("address attribute with special chars incorrect")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, err := ParseBytes(tc.input)
+
+			// Check error expectations
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if tc.errSubstring != "" && !strings.Contains(err.Error(), tc.errSubstring) {
+					t.Errorf("Error %q does not contain expected substring %q", err.Error(), tc.errSubstring)
+				}
+				return
+			}
+
+			// No error expected
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Validate object
+			if tc.validateObj != nil {
+				if err = tc.validateObj(obj); err != nil {
+					t.Errorf("Object validation failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestParseMany(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectErr     bool
+		errSubstring  string
+		expectedCount int
+		validateObjs  func([]Object) error
+	}{
+		{
+			name:          "EmptyInput",
+			input:         "",
+			expectErr:     false,
+			expectedCount: 0,
+		},
+		{
+			name:         "InvalidSyntax",
+			input:        "this is : not a valid RPSL object",
+			expectErr:    true,
+			errSubstring: "parseKey: illegal character",
+		},
+		{
+			name: "SingleObject",
+			input: "person:  John Doe\n" +
+				"address: 123 Main St\n" +
+				"source:  TEST",
+			expectErr:     false,
+			expectedCount: 1,
+			validateObjs: func(objs []Object) error {
+				if len(objs) != 1 {
+					return errors.New("expected 1 object")
+				}
+				if objs[0].Len() != 3 {
+					return errors.New("object has wrong number of attributes")
+				}
+				return nil
+			},
+		},
+		{
+			name: "MultipleObjects",
+			input: "person:  John Doe\n" +
+				"address: 123 Main St\n" +
+				"source:  TEST\n" +
+				"\n" +
+				"person:  Jane Smith\n" +
+				"address: 456 Oak Ave\n" +
+				"source:  TEST",
+			expectErr:     false,
+			expectedCount: 2,
+			validateObjs: func(objs []Object) error {
+				if len(objs) != 2 {
+					return errors.New("expected 2 objects")
+				}
+
+				person1 := objs[0].GetFirst("person")
+				if person1 == nil || *person1 != "John Doe" {
+					return errors.New("first person attribute incorrect")
+				}
+
+				person2 := objs[1].GetFirst("person")
+				if person2 == nil || *person2 != "Jane Smith" {
+					return errors.New("second person attribute incorrect")
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "MultipleObjectsWithComments",
+			input: "# Comment at start\n" +
+				"person:  John Doe\n" +
+				"source:  TEST\n" +
+				"\n" +
+				"# Comment before second object\n" +
+				"person:  Jane Smith\n" +
+				"source:  TEST\n" +
+				"\n" +
+				"# Comment before third object\n" +
+				"person:  Bob Johnson\n" +
+				"source:  TEST",
+			expectErr:     false,
+			expectedCount: 3,
+			validateObjs: func(objs []Object) error {
+				if len(objs) != 3 {
+					return errors.New("expected 3 objects")
+				}
+
+				// Check third object
+				person3 := objs[2].GetFirst("person")
+				if person3 == nil || *person3 != "Bob Johnson" {
+					return errors.New("third person attribute incorrect")
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "ObjectsWithMultipleEmptyLinesBetween",
+			input: "person:  John Doe\n" +
+				"source:  TEST\n" +
+				"\n\n\n" + // Multiple empty lines
+				"person:  Jane Smith\n" +
+				"source:  TEST",
+			expectErr:     false,
+			expectedCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objs, err := ParseMany(tc.input)
+
+			// Check error expectations
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if tc.errSubstring != "" && !strings.Contains(err.Error(), tc.errSubstring) {
+					t.Errorf("Error %q does not contain expected substring %q", err.Error(), tc.errSubstring)
+				}
+				return
+			}
+
+			// No error expected
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Check if nil is returned for empty input
+			if tc.expectedCount == 0 {
+				if objs != nil {
+					t.Errorf("Expected nil objects for empty input, got %v objects", len(objs))
+				}
+				return
+			}
+
+			// Check object count
+			if len(objs) != tc.expectedCount {
+				t.Errorf("Expected %d objects, got %d", tc.expectedCount, len(objs))
+				return
+			}
+
+			// Validate objects
+			if tc.validateObjs != nil {
+				if err = tc.validateObjs(objs); err != nil {
+					t.Errorf("Objects validation failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestParseManyBytes(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []byte
+		expectErr     bool
+		errSubstring  string
+		expectedCount int
+		validateObjs  func([]Object) error
+	}{
+		{
+			name:          "EmptyInput",
+			input:         []byte{},
+			expectErr:     false,
+			expectedCount: 0,
+		},
+		{
+			name:          "NilInput",
+			input:         nil,
+			expectErr:     false,
+			expectedCount: 0,
+		},
+		{
+			name: "MultipleObjectsWithDifferentAttributes",
+			input: []byte("person:  John Doe\n" +
+				"address: 123 Main St\n" +
+				"phone:   +1-555-1234\n" +
+				"source:  TEST\n" +
+				"\n" +
+				"organisation: ORG-EXAMPLE\n" +
+				"org-name:    Example Organization\n" +
+				"org-type:    OTHER\n" +
+				"address:     789 Corporate Blvd\n" +
+				"source:      TEST"),
+			expectErr:     false,
+			expectedCount: 2,
+			validateObjs: func(objs []Object) error {
+				if len(objs) != 2 {
+					return errors.New("expected 2 objects")
+				}
+
+				// Check first object is a person
+				if !objs[0].Exists("person") {
+					return errors.New("first object should be a person")
+				}
+
+				// Check second object is an organisation
+				orgName := objs[1].GetFirst("org-name")
+				if orgName == nil || *orgName != "Example Organization" {
+					return errors.New("org-name attribute incorrect")
+				}
+
+				// Check attribute counts
+				if objs[0].Len() != 4 {
+					return errors.New("first object should have 4 attributes")
+				}
+
+				if objs[1].Len() != 5 {
+					return errors.New("second object should have 5 attributes")
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "ObjectWithMultipleAttributesOfSameType",
+			input: []byte("route:     192.168.0.0/16\n" +
+				"origin:    AS12345\n" +
+				"descr:     Primary Network\n" +
+				"descr:     Corporate Use Only\n" +
+				"descr:     No Public Access\n" +
+				"source:    TEST"),
+			expectErr:     false,
+			expectedCount: 1,
+			validateObjs: func(objs []Object) error {
+				if len(objs) != 1 {
+					return errors.New("expected 1 object")
+				}
+
+				// Check multiple descriptions
+				descrs := objs[0].GetAll("descr")
+				if len(descrs) != 3 {
+					return errors.New("expected 3 description attributes")
+				}
+
+				if descrs[0] != "Primary Network" ||
+					descrs[1] != "Corporate Use Only" ||
+					descrs[2] != "No Public Access" {
+					return errors.New("description attributes incorrect")
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objs, err := ParseManyBytes(tc.input)
+
+			// Check error expectations
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if tc.errSubstring != "" && !strings.Contains(err.Error(), tc.errSubstring) {
+					t.Errorf("Error %q does not contain expected substring %q", err.Error(), tc.errSubstring)
+				}
+				return
+			}
+
+			// No error expected
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Check if nil is returned for empty input
+			if tc.expectedCount == 0 {
+				if objs != nil {
+					t.Errorf("Expected nil objects for empty input, got %v objects", len(objs))
+				}
+				return
+			}
+
+			// Check object count
+			if len(objs) != tc.expectedCount {
+				t.Errorf("Expected %d objects, got %d", tc.expectedCount, len(objs))
+				return
+			}
+
+			// Validate objects
+			if tc.validateObjs != nil {
+				if err = tc.validateObjs(objs); err != nil {
+					t.Errorf("Objects validation failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkParseBytes(b *testing.B) {
+	data := []byte("mntner:          DEV-MNT  # Comment \n" +
+		"descr:           DEV maintainer\n" +
+		"admin-c:         VM1-DEV\n" +
+		"tech-c:          VM1-DEV\n" +
+		"upd-to:          v.m@example.net\n" +
+		"mnt-nfy:         auto@example.net\n" +
+		"auth:            MD5-PW $1$q8Su3Hq/$rJt5M3TNLeRE4UoCh5bSH/\n" +
+		"remarks:         password: secret\n" +
+		"mnt-by:          DEV-MNT\n" +
+		"source:          DEV\n")
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := ParseBytes(data)
+		if err != nil {
+			b.Fatalf("ParseBytes error: %v", err)
+		}
 	}
 }

--- a/rpsl_test.go
+++ b/rpsl_test.go
@@ -487,8 +487,6 @@ func TestParseManyFromReader(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			objs, err := parseObjects(bytes.NewReader(tc.input))
-
-			// Check error expectations.
 			if tc.expectErr {
 				if err == nil {
 					t.Errorf("Expected error but got nil")

--- a/rpsl_test.go
+++ b/rpsl_test.go
@@ -4,7 +4,9 @@
 package rpsl
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -23,18 +25,18 @@ func TestIntegration(t *testing.T) {
 
 	for _, dataset := range datasets {
 		t.Run(dataset, func(t *testing.T) {
-			data, err := os.ReadFile("tests/data/" + dataset)
+			data, err := os.Open("tests/data/" + dataset)
 			if err != nil {
 				t.Fatalf("unable to read file: %v", err)
 			}
 
-			objects, err := ParseManyBytes(data)
+			objects, err := parseObjects(data)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			if len(objects) == 0 {
-				t.Fatalf(`parseObjects => length of %v, want > 0`, len(objects))
+				t.Fatalf(`parseObjectsFromBytes => length of %v, want > 0`, len(objects))
 			}
 		})
 	}
@@ -56,19 +58,19 @@ func TestParseAPI(t *testing.T) {
 		t.Fatalf("Parse(string) object length: got %v, want 4", obj.Len())
 	}
 
-	// Test the byte-based ParseBytes function (new API)
-	rawBytes := []byte("person: Jane Smith\naddress: 456 Example Ave\nnic-hdl: JS1-RIPE\nsource: RIPE")
-	obj, err = ParseBytes(rawBytes)
+	// Test the byte-based ParseFromBytes function (new API)
+	rawBytes := bytes.NewReader([]byte("person: Jane Smith\naddress: 456 Example Ave\nnic-hdl: JS1-RIPE\nsource: RIPE"))
+	obj, err = ParseFromReader(rawBytes)
 	if err != nil {
-		t.Fatalf("ParseBytes error: %v", err)
+		t.Fatalf("ParseFromBytes error: %v", err)
 	}
 
 	if obj == nil {
-		t.Fatalf("ParseBytes returned nil object")
+		t.Fatalf("ParseFromBytes returned nil object")
 	}
 
 	if obj.Len() != 4 {
-		t.Fatalf("ParseBytes object length: got %v, want 4", obj.Len())
+		t.Fatalf("ParseFromBytes object length: got %v, want 4", obj.Len())
 	}
 }
 
@@ -84,15 +86,15 @@ func TestParseManyAPI(t *testing.T) {
 		t.Fatalf("ParseMany(string) objects count: got %v, want 2", len(objects))
 	}
 
-	// Test the byte-based ParseManyBytes function (new API)
-	rawBytes := []byte("person: Alice Brown\naddress: 789 Example Blvd\nnic-hdl: AB1-RIPE\nsource: RIPE\n\nperson: Bob Green\naddress: 101 Example Ct\nnic-hdl: BG1-RIPE\nsource: RIPE")
-	objects, err = ParseManyBytes(rawBytes)
+	// Test the byte-based ParseManyFromBytes function (new API)
+	rawBytes := bytes.NewReader([]byte("person: Alice Brown\naddress: 789 Example Blvd\nnic-hdl: AB1-RIPE\nsource: RIPE\n\nperson: Bob Green\naddress: 101 Example Ct\nnic-hdl: BG1-RIPE\nsource: RIPE"))
+	objects, err = ParseManyFromReader(rawBytes)
 	if err != nil {
-		t.Fatalf("ParseManyBytes error: %v", err)
+		t.Fatalf("ParseManyFromBytes error: %v", err)
 	}
 
 	if len(objects) != 2 {
-		t.Fatalf("ParseManyBytes objects count: got %v, want 2", len(objects))
+		t.Fatalf("ParseManyFromBytes objects count: got %v, want 2", len(objects))
 	}
 }
 
@@ -211,106 +213,6 @@ func TestParse(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj, err := Parse(tc.input)
-
-			// Check error expectations
-			if tc.expectErr {
-				if err == nil {
-					t.Errorf("Expected error but got nil")
-				} else if tc.errSubstring != "" && !strings.Contains(err.Error(), tc.errSubstring) {
-					t.Errorf("Error %q does not contain expected substring %q", err.Error(), tc.errSubstring)
-				}
-				return
-			}
-
-			// No error expected
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
-			}
-
-			// Validate object
-			if tc.validateObj != nil {
-				if err = tc.validateObj(obj); err != nil {
-					t.Errorf("Object validation failed: %v", err)
-				}
-			}
-		})
-	}
-}
-
-func TestParseBytes(t *testing.T) {
-	tests := []struct {
-		name         string
-		input        []byte
-		expectErr    bool
-		errSubstring string
-		validateObj  func(*Object) error
-	}{
-		{
-			name:         "EmptyInput",
-			input:        []byte{},
-			expectErr:    true,
-			errSubstring: "no objects found",
-		},
-		{
-			name:         "NilInput",
-			input:        nil,
-			expectErr:    true,
-			errSubstring: "no objects found",
-		},
-		{
-			name:         "InvalidSyntax",
-			input:        []byte("this is not a valid RPSL object"),
-			expectErr:    true,
-			errSubstring: "parseKey: illegal character",
-		},
-		{
-			name: "SingleObject",
-			input: []byte("person:  John Doe\n" +
-				"address: 123 Main St\n" +
-				"phone:   +1-555-1234\n" +
-				"source:  TEST"),
-			expectErr: false,
-			validateObj: func(obj *Object) error {
-				if obj == nil {
-					return errors.New("object is nil")
-				}
-				if obj.Len() != 4 {
-					return errors.New("expected 4 attributes")
-				}
-				phone := obj.GetFirst("phone")
-				if phone == nil || *phone != "+1-555-1234" {
-					return errors.New("phone attribute incorrect")
-				}
-				return nil
-			},
-		},
-		{
-			name: "ObjectWithSpecialCharacters",
-			input: []byte("person:  Jöhn Døe\n" +
-				"address: 123 Élm Straße\n" +
-				"source:  TEST"),
-			expectErr: false,
-			validateObj: func(obj *Object) error {
-				if obj == nil {
-					return errors.New("object is nil")
-				}
-				person := obj.GetFirst("person")
-				if person == nil || *person != "Jöhn Døe" {
-					return errors.New("person attribute with special chars incorrect")
-				}
-				address := obj.GetFirst("address")
-				if address == nil || *address != "123 Élm Straße" {
-					return errors.New("address attribute with special chars incorrect")
-				}
-				return nil
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			obj, err := ParseBytes(tc.input)
 
 			// Check error expectations
 			if tc.expectErr {
@@ -490,7 +392,7 @@ func TestParseMany(t *testing.T) {
 	}
 }
 
-func TestParseManyBytes(t *testing.T) {
+func TestParseManyFromReader(t *testing.T) {
 	tests := []struct {
 		name          string
 		input         []byte
@@ -587,7 +489,7 @@ func TestParseManyBytes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			objs, err := ParseManyBytes(tc.input)
+			objs, err := parseObjects(bytes.NewReader(tc.input))
 
 			// Check error expectations
 			if tc.expectErr {
@@ -599,27 +501,16 @@ func TestParseManyBytes(t *testing.T) {
 				return
 			}
 
-			// No error expected
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 				return
 			}
 
-			// Check if nil is returned for empty input
-			if tc.expectedCount == 0 {
-				if objs != nil {
-					t.Errorf("Expected nil objects for empty input, got %v objects", len(objs))
-				}
-				return
-			}
-
-			// Check object count
 			if len(objs) != tc.expectedCount {
 				t.Errorf("Expected %d objects, got %d", tc.expectedCount, len(objs))
 				return
 			}
 
-			// Validate objects
 			if tc.validateObjs != nil {
 				if err = tc.validateObjs(objs); err != nil {
 					t.Errorf("Objects validation failed: %v", err)
@@ -629,8 +520,8 @@ func TestParseManyBytes(t *testing.T) {
 	}
 }
 
-func BenchmarkParseBytes(b *testing.B) {
-	data := []byte("mntner:          DEV-MNT  # Comment \n" +
+func BenchmarkParseFromReader(b *testing.B) {
+	data := bytes.NewReader([]byte(`mntner:          DEV-MNT  # Comment \n" +
 		"descr:           DEV maintainer\n" +
 		"admin-c:         VM1-DEV\n" +
 		"tech-c:          VM1-DEV\n" +
@@ -639,13 +530,18 @@ func BenchmarkParseBytes(b *testing.B) {
 		"auth:            MD5-PW $1$q8Su3Hq/$rJt5M3TNLeRE4UoCh5bSH/\n" +
 		"remarks:         password: secret\n" +
 		"mnt-by:          DEV-MNT\n" +
-		"source:          DEV\n")
+		"source:          DEV\n
+
+`))
 
 	b.ResetTimer()
 	for range b.N {
-		_, err := ParseBytes(data)
-		if err != nil {
-			b.Fatalf("ParseBytes error: %v", err)
+		if _, err := parseObjects(data); err != nil {
+			b.Fatalf("ParseManyFromReader error: %v", err)
+		}
+
+		if _, err := data.Seek(0, io.SeekStart); err != nil {
+			b.Fatalf("ParseManyFromReader error: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Hey! Firstly, great project, we rely on it for some of our core data processing :)

We noticed an issue with our project where memory wasn't being returned from the heap. It ended up being due to holding strings returned by `ParseMany`, more specifically the `parseObjects` function. We were able to fix this on our end by explicitly nulling data after use, but I thought I'd take some time to dive into your library to see if I could address the issue.

This PR:
- Fixes the heap issue (by slightly reworking the `parseObjects` function
- Reduces the memory allocations from the tests from 35M objects down to 19.5M objects (`newAttribute` was the main culprit)
- Adds a test to cover the `object.GetFirst` function
- Enhances a few internal errors with a little more context
- Updates exposed function comments to fix the [Go docs guidelines](https://tip.golang.org/doc/comment)

Original library memory profile (from tests):
<img width="676" alt="Screenshot 2025-03-19 at 19 19 25" src="https://github.com/user-attachments/assets/68aff8ea-8a5a-4b95-b6b5-c0fe945de79d" />

Revised library memory profile (from tests):
<img width="665" alt="image" src="https://github.com/user-attachments/assets/11fe3674-4c07-4d2a-ae9c-76899e0ebcb0" />

From our testing, this looks good and doesn't cause any regressions. But please do test it, and let me know if anything should be changed! 

