### PR TITLE
Implement Reader for Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ go get github.com/frederic-arr/rpsl-go
 
 ## Usage
 
+### Parsing a single object
+
 ```go
 package main
 
@@ -41,15 +43,54 @@ func main() {
 
 	address := obj.GetFirst("address")
 	fmt.Printf("--- Address ---\n")
-	fmt.Printf("%s\n\n", address.Value)
+	fmt.Printf("%s\n\n", *address)
 
 	maintainers := obj.GetAll("mnt-by")
 	fmt.Printf("--- Maintainers ---\n")
 	for _, m := range maintainers {
-		fmt.Printf("%s\n", m.Value)
+		fmt.Printf("%s\n", m)
 	}
 }
+```
 
+### Streaming objects
+
+```go
+package main
+
+import (
+    "errors"
+    "fmt"
+    "io"
+    "log"
+    "strings"
+
+    "github.com/frederic-arr/rpsl-go"
+)
+
+func main() {
+    raw := "person:	John Doe\n" +
+        "address:	1234 Elm Street Iceland\n" +
+        "phone:		+1 555 123456\n" +
+        "nic-hdl:	JD1234-RIPE\n" +
+        "mnt-by:	FOO-MNT\n" +
+        "mnt-by:	BAR-MNT\n" +
+        "source:	RIPE"
+
+    reader := rpsl.NewReader(strings.NewReader(raw))
+
+    for {
+        obj, err := reader.Next()
+        if err != nil {
+            if errors.Is(err, io.EOF) {
+                break
+            }
+            log.Fatalf("reader.Next => %v", err)
+        }
+
+        fmt.Printf("Parsed Object: %s\n", *obj.GetFirst("person"))
+    }
+}
 ```
 
 See the output by running `go run examples/object.go` in this repository.
@@ -59,6 +100,10 @@ See the output by running `go run examples/object.go` in this repository.
 
 - No validation regarding the object is performed.
 - No validation regarding the attribute values is performed.
+
+## Testing
+
+The tests require data which can be pulled by running `./scripts/download-dumps.sh`.
 
 ## Acknowledgements
 

--- a/object.go
+++ b/object.go
@@ -240,7 +240,6 @@ func (r *Reader) Next() (Object, error) {
 			if r.buf.Len() > 0 {
 				attributes, err := parseAttributes(r.buf.Bytes())
 				if err != nil {
-					r.err = err
 					return Object{}, err
 				}
 
@@ -272,7 +271,6 @@ func (r *Reader) Next() (Object, error) {
 	if r.buf.Len() > 0 {
 		attributes, err := parseAttributes(r.buf.Bytes())
 		if err != nil {
-			r.err = err
 			return Object{}, err
 		}
 

--- a/object.go
+++ b/object.go
@@ -184,16 +184,51 @@ func (o *Object) EnsureOne(key string) error {
 func parseObjects(r io.Reader) ([]Object, error) {
 	// Start with a small capacity that will grow if needed.
 	objects := make([]Object, 0, 4)
-	currentObject := bytes.NewBuffer(make([]byte, 0, 512))
+	reader := newReader(r)
 
-	// Pre-allocate a buffer for the scanner, but increase max size
+	for {
+		obj, err := reader.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+
+		objects = append(objects, obj)
+	}
+
+	return objects, nil
+}
+
+// Reader represents an RPSL reader that can stream RPSL objects.
+type Reader struct {
+	buf     *bytes.Buffer
+	err     error
+	scanner *bufio.Scanner
+}
+
+// newReader returns a new RPSL reader that reads from r.
+func newReader(r io.Reader) *Reader {
+	buf := make([]byte, 0, 512) // Smaller initial allocation.
 	scanner := bufio.NewScanner(r)
-	buf := make([]byte, 0, 512)      // Smaller initial allocation.
 	scanner.Buffer(buf, 4*1024*1024) // Allow large lines.
 
-	// Process the file line by line.
-	for scanner.Scan() {
-		line := scanner.Bytes()
+	return &Reader{
+		buf:     bytes.NewBuffer(make([]byte, 0, 512)),
+		scanner: scanner,
+	}
+}
+
+// Next returns the next RPSL object from the reader.
+// If there are no more objects, it returns io.EOF.
+func (r *Reader) Next() (Object, error) {
+	if r.err != nil {
+		return Object{}, r.err
+	}
+
+	for r.scanner.Scan() {
+		line := r.scanner.Bytes()
 
 		// Skip comment lines.
 		if len(line) > 0 && (line[0] == '%' || line[0] == '#') {
@@ -202,46 +237,54 @@ func parseObjects(r io.Reader) ([]Object, error) {
 
 		// Handle empty lines.
 		if len(line) == 0 {
-			if currentObject.Len() > 0 {
-				attributes, err := parseAttributes(currentObject.Bytes())
+			if r.buf.Len() > 0 {
+				attributes, err := parseAttributes(r.buf.Bytes())
 				if err != nil {
-					return nil, err
-				}
-
-				if len(attributes) > 0 {
-					objects = append(objects, Object{Attributes: attributes})
+					r.err = err
+					return Object{}, err
 				}
 
 				// Reset for the next object.
-				currentObject.Reset()
+				r.buf.Reset()
+
+				if len(attributes) > 0 {
+					return Object{Attributes: attributes}, nil
+				}
 			}
 
 			continue
 		}
 
 		// Add the line to the current object.
-		if currentObject.Len() > 0 {
-			currentObject.WriteByte('\n')
+		if r.buf.Len() > 0 {
+			r.buf.WriteByte('\n')
 		}
 
-		currentObject.Write(line)
+		r.buf.Write(line)
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, err
+	if err := r.scanner.Err(); err != nil {
+		r.err = err
+		return Object{}, err
 	}
 
-	// Don't forget the last object if there is one.
-	if currentObject.Len() > 0 {
-		attributes, err := parseAttributes(currentObject.Bytes())
+	// Remember the last object if there is one.
+	if r.buf.Len() > 0 {
+		attributes, err := parseAttributes(r.buf.Bytes())
 		if err != nil {
-			return nil, err
+			r.err = err
+			return Object{}, err
 		}
+
+		// Reset so we don't return it again.
+		r.buf.Reset()
 
 		if len(attributes) > 0 {
-			objects = append(objects, Object{Attributes: attributes})
+			return Object{Attributes: attributes}, nil
 		}
 	}
 
-	return objects, nil
+	r.err = io.EOF
+
+	return Object{}, r.err
 }

--- a/rpsl.go
+++ b/rpsl.go
@@ -131,3 +131,29 @@ func ParseManyFromReader(r io.Reader) ([]Object, error) {
 
 	return objects, nil
 }
+
+// NewReader returns a new Reader that can stream RPSL objects from an io.Reader.
+//
+// Example:
+//
+//	file, err := os.Open("rpsl_objects.txt")
+//	if err != nil {
+//	    log.Fatalf("Failed to open file: %v", err)
+//	}
+//	defer file.Close()
+//
+//	reader := rpsl.NewReader(file)
+//	for {
+//	    obj, err := reader.Next()
+//	    if err != nil {
+//	        if errors.Is(err, io.EOF) {
+//	            break
+//	        }
+//	        log.Fatalf("Failed to parse RPSL object: %v", err)
+//	    }
+//
+//	    fmt.Printf("Parsed Object: %+v\n", obj)
+//	}
+func NewReader(r io.Reader) *Reader {
+	return newReader(r)
+}

--- a/rpsl_bench_test.go
+++ b/rpsl_bench_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) The RPSL Go Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package rpsl
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func BenchmarkParse(b *testing.B) {
+	raw := "person:	John Doe\n" +
+		"address:	1234 Elm Street\n" +
+		"phone:		+1 555 123456\n" +
+		"nic-hdl:	JD1234-RIPE\n" +
+		"mnt-by:	EXAMPLE-MNT\n" +
+		"source:	RIPE\n"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Parse(raw)
+	}
+}
+
+func BenchmarkParseMany(b *testing.B) {
+	raw := "person:	John Doe\n" +
+		"address:	1234 Elm Street\n" +
+		"phone:		+1 555 123456\n" +
+		"nic-hdl:	JD1234-RIPE\n" +
+		"mnt-by:	EXAMPLE-MNT\n" +
+		"source:	RIPE\n" +
+		"\n" +
+		"person:	Jane Smith\n" +
+		"address:	5678 Oak Street\n" +
+		"phone:		+1 555 654321\n" +
+		"nic-hdl:	JS5678-RIPE\n" +
+		"mnt-by:	EXAMPLE-MNT\n" +
+		"source:	RIPE"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseMany(raw)
+	}
+}
+
+func BenchmarkParseLargeFile(b *testing.B) {
+	data, err := os.ReadFile("tests/data/ripe.db.as-set")
+	if err != nil {
+		b.Skip("skipping large file benchmark; file not found")
+	}
+	s := string(data)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseMany(s)
+	}
+}
+
+func BenchmarkReaderNext(b *testing.B) {
+	data, err := os.ReadFile("tests/data/ripe.db.as-set")
+	if err != nil {
+		b.Skip("skipping large file benchmark; file not found")
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		r := NewReader(bytes.NewReader(data))
+		for {
+			_, err = r.Next()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/rpsl_test.go
+++ b/rpsl_test.go
@@ -515,28 +515,38 @@ func TestParseManyFromReader(t *testing.T) {
 	}
 }
 
-func BenchmarkParseFromReader(b *testing.B) {
-	data := bytes.NewReader([]byte(`mntner:          DEV-MNT  # Comment \n" +
-		"descr:           DEV maintainer\n" +
-		"admin-c:         VM1-DEV\n" +
-		"tech-c:          VM1-DEV\n" +
-		"upd-to:          v.m@example.net\n" +
-		"mnt-nfy:         auto@example.net\n" +
-		"auth:            MD5-PW $1$q8Su3Hq/$rJt5M3TNLeRE4UoCh5bSH/\n" +
-		"remarks:         password: secret\n" +
-		"mnt-by:          DEV-MNT\n" +
-		"source:          DEV\n
+func TestReader(t *testing.T) {
+	input := `person: John Doe
+address: 1234 Elm Street
+source: RIPE
 
-`))
+person: Jane Smith
+address: 5678 Oak Street
+source: RIPE`
 
-	b.ResetTimer()
-	for range b.N {
-		if _, err := parseObjects(data); err != nil {
-			b.Fatalf("ParseManyFromReader error: %v", err)
-		}
+	reader := NewReader(strings.NewReader(input))
 
-		if _, err := data.Seek(0, io.SeekStart); err != nil {
-			b.Fatalf("ParseManyFromReader error: %v", err)
-		}
+	// First object
+	obj, err := reader.Next()
+	if err != nil {
+		t.Fatalf("Expected first object, got error: %v", err)
+	}
+	if *obj.GetFirst("person") != "John Doe" {
+		t.Errorf("Expected John Doe, got %v", obj.GetFirst("person"))
+	}
+
+	// Second object
+	obj, err = reader.Next()
+	if err != nil {
+		t.Fatalf("Expected second object, got error: %v", err)
+	}
+	if *obj.GetFirst("person") != "Jane Smith" {
+		t.Errorf("Expected Jane Smith, got %v", obj.GetFirst("person"))
+	}
+
+	// EOF
+	obj, err = reader.Next()
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("Expected io.EOF, got %v", err)
 	}
 }


### PR DESCRIPTION
Hello again!

This PR implements a new `Reader`. Our issue was that when parsing very large RPSL files using `ParseManyFromReader`, we'd need to hold **all** of the objects in-memory before being able to process them. With this new implementation (using an iterator like many other libraries, including the standard library's database `rows.Next()`), you can parse these files while only holding one object in-memory at a time. In our usage, this reduced our heap spikes of 2GB+ down to just 14MB. When benchmarking this new implementation versus the original, they're more or less the same across the board. Allocated space is marginally higher, but nothing worth mentioning really.

This also adds benchmarks to the repo, adds additional info to the `README` (including fixing the example code).